### PR TITLE
Register all resource providers before attempting creation

### DIFF
--- a/src/deploy-cromwell-on-azure/AzureFluentExtensions.cs
+++ b/src/deploy-cromwell-on-azure/AzureFluentExtensions.cs
@@ -11,12 +11,13 @@ namespace CromwellOnAzureDeployer
     {
         public static CloudError ToCloudError(this CloudException cloudException)
         {
-            return (JsonConvert.DeserializeObject<CloudErrorWrapper>(cloudException.Response.Content)).Error;
+            return JsonConvert.DeserializeObject<CloudErrorWrapper>(cloudException.Response.Content).Error;
         }
 
         public static CloudErrorType ToCloudErrorType(this CloudException cloudException)
         {
-            Enum.TryParse(cloudException.ToCloudError().Code, out CloudErrorType cloudErrorType);
+            var code = cloudException.ToCloudError().Code;
+            Enum.TryParse(code, out CloudErrorType cloudErrorType);
             return cloudErrorType;
         }
     }
@@ -26,6 +27,6 @@ namespace CromwellOnAzureDeployer
     }
     public enum CloudErrorType
     {
-        NotSet, ExpiredAuthenticationToken
+        NotSet, ExpiredAuthenticationToken, AuthorizationFailed
     }
 }

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -47,6 +47,7 @@ namespace CromwellOnAzureDeployer
 
         private readonly List<string> requiredResourceProviders = new List<string>
             {
+                "Microsoft.Authorization",
                 "Microsoft.Compute",
                 "Microsoft.Network",
                 "Microsoft.Batch",

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -265,44 +265,72 @@ namespace CromwellOnAzureDeployer
 
         private async Task RegisterResourceProvidersAsync()
         {
-            var cloudResourceProviders = await resourceManagerClient.Providers.ListAsync();
+            var unregisteredResourceProviders = await GetRequiredResourceProvidersNotRegisteredAsync();
 
-            var unregisteredResourceProviders = requiredResourceProviders
-                .Intersect(cloudResourceProviders
-                    .Where(rp => !rp.RegistrationState.Equals("Registered", StringComparison.OrdinalIgnoreCase))
-                    .Select(rp => rp.Namespace), StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            if (unregisteredResourceProviders.Count == 0)
+            {
+                return;
+            }
 
             try
             {
                 await Execute(
                     $"Registering resource providers...",
-                    () =>
+                    async () =>
                     {
-                        return Task.WhenAll(
+                        await Task.WhenAll(
                             unregisteredResourceProviders.Select(rp =>
                                 resourceManagerClient.Providers.RegisterAsync(rp))
                         );
+
+                        // RP registration takes a few minutes; poll until done registering
+
+                        while (!cts.IsCancellationRequested)
+                        {
+                            unregisteredResourceProviders = await GetRequiredResourceProvidersNotRegisteredAsync();
+
+                            if (unregisteredResourceProviders.Count == 0)
+                            {
+                                break;
+                            }
+                            
+                            await Task.Delay(TimeSpan.FromSeconds(15));
+                        }
+
+                        return Task.FromResult(false);
                     });
             }
             catch (Microsoft.Rest.Azure.CloudException ex) when (ex.ToCloudErrorType() == CloudErrorType.AuthorizationFailed)
             {
                 RefreshableConsole.WriteLine();
                 RefreshableConsole.WriteLine("Unable to programatically register the required resource providers.", ConsoleColor.Red);
-                RefreshableConsole.WriteLine("This can happen if you are not the Azure subscription owner, and it's an older Azure subscription.", ConsoleColor.Red);
+                RefreshableConsole.WriteLine("This can happen if you don't have the Owner or Contributor role assignment for the subscription.", ConsoleColor.Red);
                 RefreshableConsole.WriteLine();
-                RefreshableConsole.WriteLine("Please contact your Azure subscription owner and have them:", ConsoleColor.Yellow);
+                RefreshableConsole.WriteLine("Please contact the Owner or Contributor of your Azure subscription, and have them:", ConsoleColor.Yellow);
                 RefreshableConsole.WriteLine();
                 RefreshableConsole.WriteLine("1. Navigate to https://portal.azure.com", ConsoleColor.Yellow);
                 RefreshableConsole.WriteLine("2. Select Subscription -> Resource Providers", ConsoleColor.Yellow);
                 RefreshableConsole.WriteLine("3. Select each of the following and click Register:", ConsoleColor.Yellow);
                 RefreshableConsole.WriteLine();
-                unregisteredResourceProviders.ForEach(rp => RefreshableConsole.WriteLine(rp, ConsoleColor.Yellow));
+                unregisteredResourceProviders.ForEach(rp => RefreshableConsole.WriteLine($"- {rp}", ConsoleColor.Yellow));
                 RefreshableConsole.WriteLine();
                 RefreshableConsole.WriteLine("After completion, please re-attempt deployment.");
 
                 Environment.Exit(1);
             }
+        }
+        
+        private async Task<List<string>> GetRequiredResourceProvidersNotRegisteredAsync()
+        {
+            var cloudResourceProviders = await resourceManagerClient.Providers.ListAsync();
+
+            var notRegisteredResourceProviders = requiredResourceProviders
+                .Intersect(cloudResourceProviders
+                    .Where(rp => !rp.RegistrationState.Equals("Registered", StringComparison.OrdinalIgnoreCase))
+                    .Select(rp => rp.Namespace), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return notRegisteredResourceProviders;
         }
 
         private async Task ConfigureVmAsync(ConnectionInfo sshConnectionInfo)

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -48,11 +48,11 @@ namespace CromwellOnAzureDeployer
         private readonly List<string> requiredResourceProviders = new List<string>
             {
                 "Microsoft.Authorization",
-                "Microsoft.Compute",
-                "Microsoft.Network",
                 "Microsoft.Batch",
+                "Microsoft.Compute",
                 "Microsoft.DocumentDB",
                 "Microsoft.insights",
+                "Microsoft.Network",
                 "Microsoft.Storage"
             };
 

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -267,9 +267,10 @@ namespace CromwellOnAzureDeployer
         {
             var cloudResourceProviders = await resourceManagerClient.Providers.ListAsync();
 
-            var unregisteredResourceProviders = requiredResourceProviders.Intersect(cloudResourceProviders
-                .Where(rp => !rp.RegistrationState.Equals("Registered", StringComparison.OrdinalIgnoreCase))
-                .Select(rp => rp.Namespace))
+            var unregisteredResourceProviders = requiredResourceProviders
+                .Intersect(cloudResourceProviders
+                    .Where(rp => !rp.RegistrationState.Equals("Registered", StringComparison.OrdinalIgnoreCase))
+                    .Select(rp => rp.Namespace), StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             try


### PR DESCRIPTION
Older Azure Subscriptions do not have the required resource providers registered by default, resulting in failed deployment.  This PR registers all resource providers before attempting validation or resource creation.  

The current manual workaround is for the Azure subscription owner or contributor to navigate to https://portal.azure.com, select Subscription -> Resource Providers -> select each of the following and click Register:

Microsoft.Authorization
Microsoft.Batch
Microsoft.Compute
Microsoft.DocumentDB
Microsoft.insights
Microsoft.Network
Microsoft.Storage

_Note: a user must be the Azure subscription owner or contributor to register a resource provider.  When not the subscription owner or contributor, the following results for any unregistered resource providers:_

![image](https://user-images.githubusercontent.com/23408335/71701096-62806e00-2d7c-11ea-856f-92bf17c79c10.png)
