### PR TITLE
Add delay for Azure to fully propagate role assignments

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -43,7 +43,7 @@ namespace CromwellOnAzureDeployer
         private const string ConfigurationContainerName = "configuration";
         private const string InputsContainerName = "inputs";
 
-        private readonly TimeSpan armPropagationDelay = TimeSpan.FromMinutes(5);
+        private readonly TimeSpan azurePropagationDelay = TimeSpan.FromMinutes(5);
         private readonly CancellationTokenSource cts = new CancellationTokenSource();
 
         private readonly List<string> requiredResourceProviders = new List<string>
@@ -141,8 +141,8 @@ namespace CromwellOnAzureDeployer
                 await AssignVmAsDataReaderToStorageAccountAsync(vmManagedIdentity, storageAccount);
 
                 await DelayAsync(
-                    $"Waiting ({armPropagationDelay.TotalMinutes:n0}) minutes for Azure to fully propagate role assignments...", 
-                    armPropagationDelay);
+                    $"Waiting ({azurePropagationDelay.TotalMinutes:n0}) minutes for Azure to fully propagate role assignments...", 
+                    azurePropagationDelay);
 
                 await RestartVmAsync(linuxVm);
                 await WaitForSshConnectivityAsync(sshConnectionInfo);

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -141,7 +141,7 @@ namespace CromwellOnAzureDeployer
                 await AssignVmAsDataReaderToStorageAccountAsync(vmManagedIdentity, storageAccount);
 
                 await DelayAsync(
-                    $"Waiting ({armPropagationDelay.TotalMinutes:n0}) minutes for ARM to fully propagate permissions...", 
+                    $"Waiting ({armPropagationDelay.TotalMinutes:n0}) minutes for Azure to fully propagate role assignments...", 
                     armPropagationDelay);
 
                 await RestartVmAsync(linuxVm);


### PR DESCRIPTION
Occasionally during deployment, ARM (Azure's control plane) takes a few minutes to propagate role assignments between resources, including the VM and the storage account, which can result in the deployment failing and/or hanging.  This PR adds a (5) minute delay after role assignments to ensure full propagation.