### PR TITLE
Set container RegistryServer to loginServer intead of name

### DIFF
--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -396,7 +396,7 @@ namespace TesApi.Web
                     foreach (var r in registries)
                     {
                         var server = await r.GetCredentialsAsync();
-                        var info = new ContainerRegistryInfo { RegistryServer = r.Name, Username = server.Username, Password = server.AccessKeys[AccessKeyType.Primary] };
+                        var info = new ContainerRegistryInfo { RegistryServer = r.LoginServerUrl, Username = server.Username, Password = server.AccessKeys[AccessKeyType.Primary] };
                         infos.Add(info);
                     }
                 }


### PR DESCRIPTION
Should fix #29 

The Container Registry configuration seems to be using the registries name instead of the loginUrl for the RegistryServer.