### PR TITLE
Local paths in trigger file cause workflow to fail; changes to default AI log options

### DIFF
--- a/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
+++ b/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
@@ -86,7 +86,7 @@ namespace TriggerService.Tests
             var accountName = accountAuthority;
             var subdomainEndIndex = accountAuthority.IndexOf(".");
 
-            if (subdomainEndIndex >= 0)
+            if (subdomainEndIndex > 0)
             {
                 accountName = accountAuthority.Substring(0, accountAuthority.IndexOf("."));
             }

--- a/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
+++ b/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
@@ -36,7 +36,7 @@ namespace TriggerService.Tests
         public async Task GetBlobFileNameAndDataWithDefaultStorageAccountUsingLocalPath()
         {
             var accountAuthority = "fake";
-            string url = $"/{accountAuthority}/test/test.wdl";
+            var url = $"/{accountAuthority}/test/test.wdl";
 
             (var name, var data) = await GetBlobFileNameAndDataUsingMocksAsync(url, accountAuthority);
 
@@ -83,7 +83,7 @@ namespace TriggerService.Tests
 
             azStorageMock.SetupGet(az => az.AccountAuthority).Returns(accountAuthority);
 
-            string accountName = accountAuthority;
+            var accountName = accountAuthority;
             var subdomainEndIndex = accountAuthority.IndexOf(".");
 
             if (subdomainEndIndex >= 0)

--- a/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
+++ b/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
@@ -88,7 +88,7 @@ namespace TriggerService.Tests
 
             if (subdomainEndIndex > 0)
             {
-                accountName = accountAuthority.Substring(0, accountAuthority.IndexOf("."));
+                accountName = accountAuthority.Substring(0, subdomainEndIndex);
             }
             
             azStorageMock.SetupGet(az => az.AccountName).Returns(accountName);

--- a/src/TriggerService/Program.cs
+++ b/src/TriggerService/Program.cs
@@ -32,7 +32,7 @@ namespace TriggerService
                             {
                                 options.TrackExceptionsAsExceptionTelemetry = false;
                             });
-        }
+                    }
                     else
                     {
                         Console.WriteLine("Warning: AppInsights key was null, and so AppInsights logging will not be enabled.  Check if this VM has Contributor access to the Application Insights instance.");

--- a/src/TriggerService/Program.cs
+++ b/src/TriggerService/Program.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Configuration;
 using System.Threading.Tasks;
-using Microsoft.Azure.Management.Sql.Fluent.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/src/TriggerService/Program.cs
+++ b/src/TriggerService/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Configuration;
 using System.Threading.Tasks;
+using Microsoft.Azure.Management.Sql.Fluent.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -27,8 +28,12 @@ namespace TriggerService
                 {
                     if (!string.IsNullOrWhiteSpace(instrumentationKey))
                     {
-                        loggingBuilder.AddApplicationInsights(instrumentationKey);
-                    }
+                        loggingBuilder.AddApplicationInsights(instrumentationKey,
+                            options =>
+                            {
+                                options.TrackExceptionsAsExceptionTelemetry = false;
+                            });
+        }
                     else
                     {
                         Console.WriteLine("Warning: AppInsights key was null, and so AppInsights logging will not be enabled.  Check if this VM has Contributor access to the Application Insights instance.");


### PR DESCRIPTION
- If a local path to the default storage account is specified in the trigger file, an exception is thrown and the workflow is immediately failed
- Modification to default Application Insights logging options, so that all logs appear in the "traces" area instead of split between "traces" and "exceptions"