### PR TITLE
URLEncode next_page_token when listing tasks

### DIFF
--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -17,6 +17,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -177,7 +178,11 @@ namespace TesApi.Controllers
                 pageSize.HasValue ? (int)pageSize : 256,
                 pageToken);
 
-            var response = new TesListTasksResponse { Tasks = tasks.Select(t => t.Value).ToList(), NextPageToken = nextPageToken?.Replace("\"", "'") };
+            var encodedNextPageToken = ! string.IsNullOrEmpty(nextPageToken) 
+                ? HttpUtility.UrlEncode(nextPageToken.Replace("\"", "'"))
+                : nextPageToken;
+            
+            var response = new TesListTasksResponse { Tasks = tasks.Select(t => t.Value).ToList(), NextPageToken = encodedNextPageToken};
 
             return TesJsonResult(response, view);
         }

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -16,9 +16,10 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
-using System.Web;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Annotations;
@@ -167,6 +168,10 @@ namespace TesApi.Controllers
         [SwaggerResponse(statusCode: 200, type: typeof(TesListTasksResponse), description: "")]
         public virtual async Task<IActionResult> ListTasks([FromQuery]string namePrefix, [FromQuery]long? pageSize, [FromQuery]string pageToken, [FromQuery]string view)
         {
+
+            var decodedPageToken =
+                pageToken != null ? Encoding.UTF8.GetString(Base64UrlTextEncoder.Decode(pageToken)) : null;
+            
             if (pageSize < 1 || pageSize > 2047)
             {
                 logger.LogError($"pageSize invalid {pageSize}");
@@ -176,12 +181,9 @@ namespace TesApi.Controllers
             (var nextPageToken, var tasks) = await repository.GetItemsAsync(
                 t => string.IsNullOrWhiteSpace(namePrefix) || t.Name.StartsWith(namePrefix),
                 pageSize.HasValue ? (int)pageSize : 256,
-                pageToken);
-
-            var encodedNextPageToken = ! string.IsNullOrEmpty(nextPageToken) 
-                ? HttpUtility.UrlEncode(nextPageToken.Replace("\"", "'"))
-                : nextPageToken;
+                decodedPageToken);
             
+            var encodedNextPageToken = nextPageToken != null ? Base64UrlTextEncoder.Encode(Encoding.UTF8.GetBytes(nextPageToken)) : null;
             var response = new TesListTasksResponse { Tasks = tasks.Select(t => t.Value).ToList(), NextPageToken = encodedNextPageToken};
 
             return TesJsonResult(response, view);


### PR DESCRIPTION
fixes #46 

made it so `next_page_tokens` can be set directly without having to encode them