### PR TITLE
Treating NodeDiskFull as executor error. Requeuing active jobs where …

### DIFF
--- a/src/TesApi.Tests/DeleteOrphanedBatchPoolsHostedServiceTests.cs
+++ b/src/TesApi.Tests/DeleteOrphanedBatchPoolsHostedServiceTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using TesApi.Web;
+
+namespace TesApi.Tests
+{
+    [TestClass]
+    public class DeleteOrphanedBatchPoolsHostedServiceTests
+    {
+        [TestMethod]
+        public async Task DeleteOrphanedAutoPoolsServiceOnlyDeletesPoolsNotReferencedByJobs()
+        {
+            var activePoolIds = new List<string> { "1", "2", "3" };
+            var poolIdsReferencedByJobs = new List<string> { "3", "4" };
+
+            var azureProxy = new Mock<IAzureProxy>();
+            azureProxy.Setup(p => p.GetActivePoolIdsAsync(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).ReturnsAsync(activePoolIds);
+            azureProxy.Setup(p => p.GetPoolIdsReferencedByJobsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(poolIdsReferencedByJobs);
+
+            var deleteCompletedBatchJobsHostedService = new DeleteOrphanedAutoPoolsHostedService(azureProxy.Object, new NullLogger<DeleteOrphanedAutoPoolsHostedService>());
+
+            await deleteCompletedBatchJobsHostedService.StartAsync(default);
+
+            azureProxy.Verify(i => i.GetActivePoolIdsAsync("TES_", TimeSpan.FromMinutes(30), It.IsAny<CancellationToken>()));
+            azureProxy.Verify(i => i.GetPoolIdsReferencedByJobsAsync(It.IsAny<CancellationToken>()));
+            azureProxy.Verify(i => i.DeleteBatchPoolAsync("1", It.IsAny<CancellationToken>()), Times.Once);
+            azureProxy.Verify(i => i.DeleteBatchPoolAsync("2", It.IsAny<CancellationToken>()), Times.Once);
+            azureProxy.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/src/TesApi.Web/BatchTaskState.cs
+++ b/src/TesApi.Web/BatchTaskState.cs
@@ -32,6 +32,11 @@ namespace TesApi.Web
         CompletedWithErrors,
 
         /// <summary>
+        /// Batch job is active and has non-null ExecutionInformation.PoolId but pool does not exist
+        /// </summary>
+        ActiveJobWithMissingAutoPool,
+
+        /// <summary>
         /// Batch job is either not found or is being deleted
         /// </summary>
         JobNotFound,
@@ -50,6 +55,11 @@ namespace TesApi.Web
         /// Azure Batch was unable to allocate a machine for the job.  This could be due to either a temporary or permanent unavailability of the given VM SKU
         /// </summary>
         NodeAllocationFailed,
+
+        /// <summary>
+        /// Azure Batch machine disk was too small for the task.
+        /// </summary>
+        NodeDiskFull,
 
         /// <summary>
         /// Azure Batch pre-empted the execution of this task while running on a low-priority node

--- a/src/TesApi.Web/DeleteOrphanedAutoPoolsHostedService.cs
+++ b/src/TesApi.Web/DeleteOrphanedAutoPoolsHostedService.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace TesApi.Web
+{
+    /// <summary>
+    /// Background service to delete Batch auto pools that do not have the corresponding Batch job.
+    /// This happens in rare cases when auto pool job is rapidly created and deleted but the pool continues with creation,
+    /// resulting in an active pool with a single node that is not attached to a job.
+    /// </summary>
+    public class DeleteOrphanedAutoPoolsHostedService : BackgroundService
+    {
+        private static readonly TimeSpan runInterval = TimeSpan.FromHours(1);
+        private static readonly TimeSpan minPoolAge = TimeSpan.FromMinutes(30);
+        private static readonly string autoPoolIdPrefix = "TES_";
+        private readonly IAzureProxy azureProxy;
+        private readonly ILogger<DeleteOrphanedAutoPoolsHostedService> logger;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="azureProxy">Azure Proxy</param>
+        /// <param name="logger">The logger instance</param>
+        public DeleteOrphanedAutoPoolsHostedService(IAzureProxy azureProxy, ILogger<DeleteOrphanedAutoPoolsHostedService> logger)
+        {
+            this.azureProxy = azureProxy;
+            this.logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Orphaned pool cleanup service started");
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await DeleteOrphanedAutoPoolsAsync(cancellationToken);
+                }
+                catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
+                {
+                    logger.LogError(ex, ex.Message);
+                }
+
+                await Task.Delay(runInterval, cancellationToken);
+            }
+        }
+
+        private async Task DeleteOrphanedAutoPoolsAsync(CancellationToken cancellationToken)
+        {
+            var activePoolIds = (await azureProxy.GetActivePoolIdsAsync(autoPoolIdPrefix, minPoolAge, cancellationToken)).ToList();
+
+            if (activePoolIds.Any())
+            {
+                var poolIdsReferencedByJobs = (await azureProxy.GetPoolIdsReferencedByJobsAsync(cancellationToken)).ToList();
+
+                var orphanedPoolIds = activePoolIds.Except(poolIdsReferencedByJobs);
+
+                foreach (var orphanedPoolId in orphanedPoolIds)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    logger.LogInformation($"Deleting orphanded pool {orphanedPoolId}, since no jobs reference it.");
+                    await azureProxy.DeleteBatchPoolAsync(orphanedPoolId, cancellationToken);
+                }
+            }
+        }
+    }
+}

--- a/src/TesApi.Web/IAzureProxy.cs
+++ b/src/TesApi.Web/IAzureProxy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Batch;
 using Microsoft.Azure.Management.Batch.Models;
@@ -128,5 +129,22 @@ namespace TesApi.Web
         /// </summary>
         /// <returns>List of Batch job ids</returns>
         Task<IEnumerable<string>> ListOldJobsToDeleteAsync(TimeSpan oldestJobAge);
+
+        /// <summary>
+        /// Gets the list of active pool ids matching the prefix and with creation time older than the minAge
+        /// </summary>
+        /// <returns>Active pool ids</returns>
+        Task<IEnumerable<string>> GetActivePoolIdsAsync(string prefix, TimeSpan minAge, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets the list of pool ids referenced by the jobs
+        /// </summary>
+        /// <returns>Pool ids</returns>
+        Task<IEnumerable<string>> GetPoolIdsReferencedByJobsAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Deletes the specified pool
+        /// </summary>
+        Task DeleteBatchPoolAsync(string poolId, CancellationToken cancellationToken);
     }
 }

--- a/src/TesApi.Web/Scheduler.cs
+++ b/src/TesApi.Web/Scheduler.cs
@@ -147,10 +147,11 @@ namespace TesApi.Web
                         if (++tesTask.Value.ErrorCount > 3) // TODO: Should we increment this for exceptions here (current behaviour) or the attempted executions on the batch?
                         {
                             tesTask.Value.State = TesState.SYSTEMERROREnum;
+                            tesTask.Value.EndTime = DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz", DateTimeFormatInfo.InvariantInfo);
+                            tesTask.Value.WriteToSystemLog(exc.Message, exc.StackTrace);
                         }
 
                         logger.LogError(exc, $"TES Task '{tesTask.Value.Id}' threw an exception.");
-                        tesTask.Value.EndTime = DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz", DateTimeFormatInfo.InvariantInfo);
                         await repository.UpdateItemAsync(tesTask.Value.Id, tesTask);
                     }
                 }

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -87,6 +87,7 @@ namespace TesApi.Web
 
             services.AddHostedService<Scheduler>();
             services.AddHostedService<DeleteCompletedBatchJobsHostedService>();
+            services.AddHostedService<DeleteOrphanedAutoPoolsHostedService>();
 
             // Configure AppInsights Azure Service when in PRODUCTION environment
             if (hostingEnvironment.IsProduction())

--- a/src/TesApi.Web/TesTaskExtensions.cs
+++ b/src/TesApi.Web/TesTaskExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using TesApi.Models;
+
+namespace TesApi.Web
+{
+    /// <summary>
+    /// <see cref="TesTask"/> extensions
+    /// </summary>
+    public static class TesTaskExtensions
+    {
+        /// <summary>
+        /// Writes to <see cref="TesTask"/> system log.
+        /// </summary>
+        /// <param name="tesTask"><see cref="TesTask"/></param>
+        /// <param name="logEntries">List of strings to write to the log.</param>
+        public static void WriteToSystemLog(this TesTask tesTask, params string[] logEntries)
+        {
+            if (logEntries != null && logEntries.Any(e => !string.IsNullOrEmpty(e)))
+            {
+                tesTask.Logs = tesTask.Logs ?? new List<TesTaskLog>();
+                tesTask.Logs.Add(new TesTaskLog { SystemLogs = logEntries.ToList() });
+            }
+        }
+    }
+}


### PR DESCRIPTION
…pool was not created. Deleting TES pools not referenced by jobs. Improved error logging.

Closes #41 
Closes #48
Closes #49