### PR TITLE
task/UpdateCPUandHDDruntimeparams

### DIFF
--- a/samples/quickstart/FastqToUbamSingleSample.wdl
+++ b/samples/quickstart/FastqToUbamSingleSample.wdl
@@ -41,6 +41,9 @@ task FastqToUbam {
     String library
     String platform
     String platform_unit
+    
+    #scale file size appropriately for differing inputs. There are 2 FASTQ files, and you need to write out the new combined uBAM, plus buffer 
+    Int disk_size = ceil((size(fastqs[0]) + size(fastqs[1])) * 2.5)
 
     String docker_image
     String gotc_path
@@ -61,7 +64,7 @@ task FastqToUbam {
         docker: docker_image
         memory: "32 GB"
         cpu: "16"
-        disk: "500 GB"
+        disk: disk_size
     }
 
     output {

--- a/samples/quickstart/FastqToUbamSingleSample.wdl
+++ b/samples/quickstart/FastqToUbamSingleSample.wdl
@@ -60,7 +60,8 @@ task FastqToUbam {
     runtime {
         docker: docker_image
         memory: "32 GB"
-        cpu: "8"
+        cpu: "16"
+        disk: "500 GB"
     }
 
     output {


### PR DESCRIPTION
1) Changed "CPU" from 8-->16
2) Added "Disk" runtime parameter and set to "500 GB"

This allows for WDL to operate on any input including up to deep sequencing of samples, making it more robust.