### PR TITLE
Trigger service multiple input files

### DIFF
--- a/src/Common/Workflow.cs
+++ b/src/Common/Workflow.cs
@@ -8,6 +8,7 @@ namespace Common
     public class Workflow
     {
         public string WorkflowUrl { get; set; }
+        public string WorkflowInputsUrl { get; set; }
         public List<string> WorkflowInputsUrls { get; set; }
         public string WorkflowOptionsUrl { get; set; }
         public string WorkflowDependenciesUrl { get; set; }

--- a/src/Common/Workflow.cs
+++ b/src/Common/Workflow.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace Common
 {
     public class Workflow
     {
         public string WorkflowUrl { get; set; }
-        public string WorkflowInputsUrl { get; set; }
+        public List<string> WorkflowInputsUrls { get; set; }
         public string WorkflowOptionsUrl { get; set; }
         public string WorkflowDependenciesUrl { get; set; }
     }

--- a/src/CromwellApiClient/CromwellApiClient.cs
+++ b/src/CromwellApiClient/CromwellApiClient.cs
@@ -76,9 +76,9 @@ namespace CromwellApiClient
                 new FileToPost { ParameterName = "workflowSource", Filename = workflowSourceFilename, Data = EncodeToUtf8AndRemoveTabsAndDecode(workflowSourceData) },
             };
 
-            for (int i = 1; i <= workflowInputsFilenames.Count; i++)
+            for (var i = 0; i < workflowInputsFilenames.Count; i++)
             {
-                var parameterName = i == 1 ? "workflowInputs" : "workflowInputs_" + i;
+                var parameterName = i == 0 ? "workflowInputs" : "workflowInputs_" + (i + 1);
                 files.Add(new FileToPost { ParameterName = parameterName, Filename = workflowInputsFilenames[i], Data = EncodeToUtf8AndRemoveTabsAndDecode(workflowInputsData[i]) });
             }
 

--- a/src/CromwellApiClient/CromwellApiClient.cs
+++ b/src/CromwellApiClient/CromwellApiClient.cs
@@ -65,8 +65,8 @@ namespace CromwellApiClient
         public async Task<PostWorkflowResponse> PostWorkflowAsync(
             string workflowSourceFilename,
             byte[] workflowSourceData,
-            string workflowInputsFilename,
-            byte[] workflowInputsData,
+            List<string> workflowInputsFilenames,
+            List<byte[]> workflowInputsData,
             string workflowOptionsFilename = null,
             byte[] workflowOptionsData = null,
             string workflowDependenciesFilename = null,
@@ -74,8 +74,13 @@ namespace CromwellApiClient
         {
             var files = new List<FileToPost> {
                 new FileToPost { ParameterName = "workflowSource", Filename = workflowSourceFilename, Data = EncodeToUtf8AndRemoveTabsAndDecode(workflowSourceData) },
-                new FileToPost { ParameterName = "workflowInputs", Filename = workflowInputsFilename, Data = EncodeToUtf8AndRemoveTabsAndDecode(workflowInputsData) }
             };
+
+            for (int i = 1; i <= workflowInputsFilenames.Count; i++)
+            {
+                var parameterName = i == 1 ? "workflowInputs" : "workflowInputs_" + i;
+                files.Add(new FileToPost { ParameterName = parameterName, Filename = workflowInputsFilenames[i], Data = EncodeToUtf8AndRemoveTabsAndDecode(workflowInputsData[i]) });
+            }
 
             if (workflowOptionsFilename != null && workflowOptionsData != null)
             {

--- a/src/CromwellApiClient/ICromwellApiClient.cs
+++ b/src/CromwellApiClient/ICromwellApiClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace CromwellApiClient
@@ -11,8 +12,8 @@ namespace CromwellApiClient
         string GetUrl();
         Task<PostWorkflowResponse> PostWorkflowAsync(string workflowSourceFilename,
             byte[] workflowSourceData,
-            string workflowInputsFilename,
-            byte[] workflowInputsData,
+            List<string> workflowInputsFilenames,
+            List<byte[]> workflowInputsData,
             string workflowOptionsFilename = null,
             byte[] workflowOptionsData = null,
             string workflowDependenciesFilename = null,

--- a/src/TriggerService/CromwellOnAzureEnvironment.cs
+++ b/src/TriggerService/CromwellOnAzureEnvironment.cs
@@ -92,11 +92,20 @@ namespace TriggerService
                     var workflowInputsData = new List<byte[]>();
 
                     (var workflowSourceFilename, var workflowSourceData) = await GetBlobFileNameAndData(triggerInfo.WorkflowUrl);
-                    foreach (var workflowInputsUrl in triggerInfo.WorkflowInputsUrls)
+                    if (triggerInfo.WorkflowInputsUrl != null)
                     {
-                        (var workflowInputsFilename, var workflowInputsFileData) = await GetBlobFileNameAndData(workflowInputsUrl);
+                        (var workflowInputsFilename, var workflowInputsFileData) = await GetBlobFileNameAndData(triggerInfo.WorkflowInputsUrl);
                         workflowInputsFilenames.Add(workflowInputsFilename);
                         workflowInputsData.Add(workflowInputsFileData);
+                    }
+                    if (triggerInfo.WorkflowInputsUrls != null)
+                    {
+                        foreach (var workflowInputsUrl in triggerInfo.WorkflowInputsUrls)
+                        {
+                            (var workflowInputsFilename, var workflowInputsFileData) = await GetBlobFileNameAndData(workflowInputsUrl);
+                            workflowInputsFilenames.Add(workflowInputsFilename);
+                            workflowInputsData.Add(workflowInputsFileData);
+                        }
                     }
                     (var workflowOptionsFilename, var workflowOptionsData) = await GetBlobFileNameAndData(triggerInfo.WorkflowOptionsUrl);
                     (var workflowDependenciesFilename, var workflowDependenciesData) = await GetBlobFileNameAndData(triggerInfo.WorkflowDependenciesUrl);

--- a/src/TriggerService/CromwellOnAzureEnvironment.cs
+++ b/src/TriggerService/CromwellOnAzureEnvironment.cs
@@ -88,16 +88,23 @@ namespace TriggerService
                     var blobTriggerJson = await blobTrigger.DownloadTextAsync();
                     var triggerInfo = JsonConvert.DeserializeObject<Workflow>(blobTriggerJson);
                     var tasks = new List<Task>();
+                    var workflowInputsFilenames = new List<string>();
+                    var workflowInputsData = new List<byte[]>();
 
                     (var workflowSourceFilename, var workflowSourceData) = await GetBlobFileNameAndData(triggerInfo.WorkflowUrl);
-                    (var workflowInputsFilename, var workflowInputsData) = await GetBlobFileNameAndData(triggerInfo.WorkflowInputsUrl);
+                    foreach (var workflowInputsUrl in triggerInfo.WorkflowInputsUrls)
+                    {
+                        (var workflowInputsFilename, var workflowInputsFileData) = await GetBlobFileNameAndData(workflowInputsUrl);
+                        workflowInputsFilenames.Add(workflowInputsFilename);
+                        workflowInputsData.Add(workflowInputsFileData);
+                    }
                     (var workflowOptionsFilename, var workflowOptionsData) = await GetBlobFileNameAndData(triggerInfo.WorkflowOptionsUrl);
                     (var workflowDependenciesFilename, var workflowDependenciesData) = await GetBlobFileNameAndData(triggerInfo.WorkflowDependenciesUrl);
 
                     var response = await cromwellApiClient.PostWorkflowAsync(
                         workflowSourceFilename,
                         workflowSourceData,
-                        workflowInputsFilename,
+                        workflowInputsFilenames,
                         workflowInputsData,
                         workflowOptionsFilename,
                         workflowOptionsData,

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -972,7 +972,7 @@ namespace CromwellOnAzureDeployer
             var workflow = new Workflow
             {
                 WorkflowUrl = $"/{configuration.StorageAccountName}/{InputsContainerName}/test/test.wdl",
-                WorkflowInputsUrl = $"/{configuration.StorageAccountName}/{InputsContainerName}/test/test.json"
+                WorkflowInputsUrls = new List<string> { $"/{configuration.StorageAccountName}/{InputsContainerName}/test/test.json" }
             };
 
             var json = JsonConvert.SerializeObject(workflow, Formatting.Indented);


### PR DESCRIPTION
changing the TriggerService to allow multiple input files, which is allowed by Cromwell
to do this, added a new Workflow field "WorkflowInputsUrls" (note the "s" at the end), which is a list of files
Cromwell stipulates that the latter file will have its values used if there is any conflict

the change is backwards compatible to allow the original trigger file form where one file is specified
therefore the field "WorkflowInputsUrl" (no "s" at the end) remains

I left it so that it's possible to specify both single and multiple files at the same time using both fields. In this case the single file field will be the first one used, followed by the ones in the list.