### PR TITLE
Using Blobxfer for more resilient file uploads.

### DIFF
--- a/src/TesApi.Tests/BatchSchedulerTests.cs
+++ b/src/TesApi.Tests/BatchSchedulerTests.cs
@@ -85,8 +85,8 @@ namespace TesApi.Tests
             (_, var cloudTask, _) = await ProcessTesTaskAndGetBatchJobArgumentsAsync();
 
             Assert.AreEqual(2, cloudTask.ResourceFiles.Count());
-            Assert.IsTrue(cloudTask.ResourceFiles.Any(f => f.FilePath.Equals("/mnt/cromwell-executions/workflow1/workflowId1/call-Task1/execution/upload_files_script")));
-            Assert.IsTrue(cloudTask.ResourceFiles.Any(f => f.FilePath.Equals("/mnt/cromwell-executions/workflow1/workflowId1/call-Task1/execution/download_files_script")));
+            Assert.IsTrue(cloudTask.ResourceFiles.Any(f => f.FilePath.Equals("/mnt/cromwell-executions/workflow1/workflowId1/call-Task1/execution/_batch/upload_files_script")));
+            Assert.IsTrue(cloudTask.ResourceFiles.Any(f => f.FilePath.Equals("/mnt/cromwell-executions/workflow1/workflowId1/call-Task1/execution/_batch/download_files_script")));
         }
 
         [TestMethod]

--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -265,9 +265,8 @@ namespace TesApi.Web
             try
             {
                 var nodeAllocationFailed = false;
-                var imageDownloadFailed = false;
-                string imageDownloadErrorMessage = null;
-                var nodeDiskFull = false;
+                string nodeErrorCode = null;
+                IEnumerable<string> nodeErrorDetails = null;
                 var activeJobWithMissingAutoPool = false;
                 TaskState? taskState = null;
                 TaskExecutionInformation taskExecutionInformation = null;
@@ -316,12 +315,10 @@ namespace TesApi.Web
                         {
                             var nodeError = node.Errors?.FirstOrDefault();
 
-                            if (nodeError != null)
+                            if (nodeError != null && nodeError.Code != null)
                             {
-                                imageDownloadFailed = nodeError.Code?.Equals("ContainerInvalidImage", StringComparison.OrdinalIgnoreCase) ?? false;
-                                imageDownloadErrorMessage = imageDownloadFailed ? nodeError.ErrorDetails?.LastOrDefault()?.Value : null;
-
-                                nodeDiskFull = nodeError.Code?.Equals("DiskFull", StringComparison.OrdinalIgnoreCase) ?? false;
+                                nodeErrorCode = nodeError.Code;
+                                nodeErrorDetails = nodeError.ErrorDetails?.Select(e => e.Value);
                             }
                         }
                     }
@@ -351,9 +348,8 @@ namespace TesApi.Web
                     ActiveJobWithMissingAutoPool = activeJobWithMissingAutoPool,
                     AttemptNumber = attemptNumber,
                     NodeAllocationFailed = nodeAllocationFailed,
-                    ImageDownloadFailed = imageDownloadFailed,
-                    ImageDownloadErrorMessage = imageDownloadErrorMessage,
-                    NodeDiskFull = nodeDiskFull,
+                    NodeErrorCode = nodeErrorCode,
+                    NodeErrorDetails = nodeErrorDetails,
                     JobState = job.State,
                     JobStartTime = job.ExecutionInformation?.StartTime,
                     JobEndTime = job.ExecutionInformation?.EndTime,
@@ -829,9 +825,8 @@ namespace TesApi.Web
             public bool ActiveJobWithMissingAutoPool { get; set; }
             public int AttemptNumber { get; set; }
             public bool NodeAllocationFailed { get; set; }
-            public bool ImageDownloadFailed { get; set; }
-            public string ImageDownloadErrorMessage { get; set; }
-            public bool NodeDiskFull { get; set; }
+            public string NodeErrorCode { get; set; }
+            public IEnumerable<string> NodeErrorDetails { get; set; }
             public JobState? JobState { get; set; }
             public DateTime? JobStartTime { get; set; }
             public DateTime? JobEndTime { get; set; }

--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -265,6 +265,8 @@ namespace TesApi.Web
             try
             {
                 var nodeAllocationFailed = false;
+                var imageDownloadFailed = false;
+                string imageDownloadErrorMessage = null;
                 var nodeDiskFull = false;
                 var activeJobWithMissingAutoPool = false;
                 TaskState? taskState = null;
@@ -312,7 +314,15 @@ namespace TesApi.Web
 
                         if (node != null)
                         {
-                            nodeDiskFull = node.Errors?.FirstOrDefault()?.Code?.Equals("DiskFull", StringComparison.OrdinalIgnoreCase) ?? false;
+                            var nodeError = node.Errors?.FirstOrDefault();
+
+                            if (nodeError != null)
+                            {
+                                imageDownloadFailed = nodeError.Code?.Equals("ContainerInvalidImage", StringComparison.OrdinalIgnoreCase) ?? false;
+                                imageDownloadErrorMessage = imageDownloadFailed ? nodeError.ErrorDetails?.LastOrDefault()?.Value : null;
+
+                                nodeDiskFull = nodeError.Code?.Equals("DiskFull", StringComparison.OrdinalIgnoreCase) ?? false;
+                            }
                         }
                     }
                     else
@@ -341,6 +351,8 @@ namespace TesApi.Web
                     ActiveJobWithMissingAutoPool = activeJobWithMissingAutoPool,
                     AttemptNumber = attemptNumber,
                     NodeAllocationFailed = nodeAllocationFailed,
+                    ImageDownloadFailed = imageDownloadFailed,
+                    ImageDownloadErrorMessage = imageDownloadErrorMessage,
                     NodeDiskFull = nodeDiskFull,
                     JobState = job.State,
                     JobStartTime = job.ExecutionInformation?.StartTime,
@@ -817,6 +829,8 @@ namespace TesApi.Web
             public bool ActiveJobWithMissingAutoPool { get; set; }
             public int AttemptNumber { get; set; }
             public bool NodeAllocationFailed { get; set; }
+            public bool ImageDownloadFailed { get; set; }
+            public string ImageDownloadErrorMessage { get; set; }
             public bool NodeDiskFull { get; set; }
             public JobState? JobState { get; set; }
             public DateTime? JobStartTime { get; set; }

--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -56,6 +56,7 @@ namespace TesApi.Web
         /// The constructor
         /// </summary>
         /// <param name="batchAccountName">Batch account name</param>
+        /// <param name="azureOfferDurableId">Azure offer id</param>
         /// <param name="logger">The logger</param>
         public AzureProxy(string batchAccountName, string azureOfferDurableId, ILogger logger)
         {
@@ -227,14 +228,12 @@ namespace TesApi.Web
         /// Creates a new Azure Batch job
         /// </summary>
         /// <param name="jobId"></param>
-        /// <param name="jobPreparationTask"></param>
         /// <param name="cloudTask"></param>
         /// <param name="poolInformation"></param>
         /// <returns></returns>
-        public async Task CreateBatchJobAsync(string jobId, JobPreparationTask jobPreparationTask, CloudTask cloudTask, PoolInformation poolInformation)
+        public async Task CreateBatchJobAsync(string jobId, CloudTask cloudTask, PoolInformation poolInformation)
         {
             var job = batchClient.JobOperations.CreateJob(jobId, poolInformation);
-            job.JobPreparationTask = jobPreparationTask;
 
             await job.CommitAsync();
 
@@ -325,8 +324,6 @@ namespace TesApi.Web
                     }
                 }
 
-                var jobPreparationTaskExecutionInformation = (await batchClient.JobOperations.ListJobPreparationAndReleaseTaskStatus(job.Id).ToListAsync()).FirstOrDefault()?.JobPreparationTaskExecutionInformation;
-
                 try
                 {
                     var batchTask = await batchClient.JobOperations.GetTaskAsync(job.Id, tesTaskId);
@@ -349,14 +346,6 @@ namespace TesApi.Web
                     JobStartTime = job.ExecutionInformation?.StartTime,
                     JobEndTime = job.ExecutionInformation?.EndTime,
                     JobSchedulingError = job.ExecutionInformation?.SchedulingError,
-                    JobPreparationTaskState = jobPreparationTaskExecutionInformation?.State,
-                    JobPreparationTaskExecutionResult = jobPreparationTaskExecutionInformation?.Result,
-                    JobPreparationTaskStartTime = jobPreparationTaskExecutionInformation?.StartTime,
-                    JobPreparationTaskEndTime = jobPreparationTaskExecutionInformation?.EndTime,
-                    JobPreparationTaskExitCode = jobPreparationTaskExecutionInformation?.ExitCode,
-                    JobPreparationTaskFailureInformation = jobPreparationTaskExecutionInformation?.FailureInformation,
-                    JobPreparationTaskContainerState = jobPreparationTaskExecutionInformation?.ContainerInformation?.State,
-                    JobPreparationTaskContainerError = jobPreparationTaskExecutionInformation?.ContainerInformation?.Error,
                     TaskState = taskState,
                     TaskExecutionResult = taskExecutionInformation?.Result,
                     TaskStartTime = taskExecutionInformation?.StartTime,
@@ -833,14 +822,6 @@ namespace TesApi.Web
             public DateTime? JobStartTime { get; set; }
             public DateTime? JobEndTime { get; set; }
             public JobSchedulingError JobSchedulingError { get; set; }
-            public JobPreparationTaskState? JobPreparationTaskState { get; set; }
-            public int? JobPreparationTaskExitCode { get; set; }
-            public TaskExecutionResult? JobPreparationTaskExecutionResult { get; set; }
-            public DateTime? JobPreparationTaskStartTime { get; set; }
-            public DateTime? JobPreparationTaskEndTime { get; set; }
-            public TaskFailureInformation JobPreparationTaskFailureInformation { get; set; }
-            public string JobPreparationTaskContainerState { get; set; }
-            public string JobPreparationTaskContainerError { get; set; }
             public TaskState? TaskState { get; set; }
             public int? TaskExitCode { get; set; }
             public TaskExecutionResult? TaskExecutionResult { get; set; }

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -455,7 +455,7 @@ namespace TesApi.Web
 
             var batchExecutionDirectoryUrl = await MapLocalPathToSasUrlAsync($"{batchExecutionDirectoryPath}", getContainerSas: true);
 
-            var cloudTask = new CloudTask(taskId, $"/bin/sh -c '{taskCommand}'")
+            var cloudTask = new CloudTask(taskId, $"/bin/sh -c \"{taskCommand.Trim()}\"")
             {
                 UserIdentity = new UserIdentity(new AutoUserSpecification(elevationLevel: ElevationLevel.Admin, scope: AutoUserScope.Pool)),
                 ResourceFiles = new List<ResourceFile> { ResourceFile.FromUrl(downloadFilesScriptUrl, $"/mnt{downloadFilesScriptPath}"), ResourceFile.FromUrl(uploadFilesScriptUrl, $"/mnt{uploadFilesScriptPath}") },

--- a/src/TesApi.Web/BatchTaskState.cs
+++ b/src/TesApi.Web/BatchTaskState.cs
@@ -69,6 +69,11 @@ namespace TesApi.Web
         /// <summary>
         /// Batch job exists but task is missing. This can happen if scheduler goes down after creating the job but before creating the task.
         /// </summary>
-        MissingBatchTask
+        MissingBatchTask,
+
+        /// <summary>
+        /// Node failed to download the docker image
+        /// </summary>
+        ImageDownloadFailed
     }
 }

--- a/src/TesApi.Web/BatchTaskState.cs
+++ b/src/TesApi.Web/BatchTaskState.cs
@@ -57,11 +57,6 @@ namespace TesApi.Web
         NodeAllocationFailed,
 
         /// <summary>
-        /// Azure Batch machine disk was too small for the task.
-        /// </summary>
-        NodeDiskFull,
-
-        /// <summary>
         /// Azure Batch pre-empted the execution of this task while running on a low-priority node
         /// </summary>
         NodePreempted,
@@ -72,8 +67,8 @@ namespace TesApi.Web
         MissingBatchTask,
 
         /// <summary>
-        /// Node failed to download the docker image
+        /// Node failed during startup or task execution (for example, ContainerInvalidImage, DiskFull)
         /// </summary>
-        ImageDownloadFailed
+        NodeFailedDuringStartupOrExecution
     }
 }

--- a/src/TesApi.Web/BatchTaskState.cs
+++ b/src/TesApi.Web/BatchTaskState.cs
@@ -69,11 +69,6 @@ namespace TesApi.Web
         /// <summary>
         /// Batch job exists but task is missing. This can happen if scheduler goes down after creating the job but before creating the task.
         /// </summary>
-        MissingBatchTask,
-
-        /// <summary>
-        /// Preparation task failed
-        /// </summary>
-        PreparationTaskFailed
+        MissingBatchTask
     }
 }

--- a/src/TesApi.Web/IAzureProxy.cs
+++ b/src/TesApi.Web/IAzureProxy.cs
@@ -35,10 +35,9 @@ namespace TesApi.Web
         /// Creates a new Azure Batch job
         /// </summary>
         /// <param name="jobId"></param>
-        /// <param name="jobPreparationTask"></param>
         /// <param name="cloudTask"></param>
         /// <param name="poolInformation"></param>
-        Task CreateBatchJobAsync(string jobId, JobPreparationTask jobPreparationTask, CloudTask cloudTask, PoolInformation poolInformation);
+        Task CreateBatchJobAsync(string jobId, CloudTask cloudTask, PoolInformation poolInformation);
 
         /// <summary>
         /// Retrieves the list of container registries that the TES server has access to.

--- a/src/TesApi.Web/Scheduler.cs
+++ b/src/TesApi.Web/Scheduler.cs
@@ -25,6 +25,7 @@ namespace TesApi.Web
         private readonly ILogger<Scheduler> logger;
         private readonly CancellationTokenSource mainProcess = new CancellationTokenSource();
         private bool isStopped;
+        private readonly TimeSpan runInterval = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// Default constructor
@@ -77,7 +78,6 @@ namespace TesApi.Web
         /// </summary>
         private async Task RunAsync()
         {
-            var runInterval = TimeSpan.FromSeconds(1);
             logger.LogInformation("Scheduler started.");
 
             while (!mainProcess.IsCancellationRequested)
@@ -91,7 +91,7 @@ namespace TesApi.Web
                     logger.LogError(exc, exc.Message);
                 }
 
-                await Task.Delay(runInterval);
+                await Task.Delay(this.runInterval);
             }
 
             isStopped = true;
@@ -126,7 +126,7 @@ namespace TesApi.Web
                         if (isModified)
                         {
                             //task has transitioned
-                            if (tesTask.Value.State == TesState.CANCELEDEnum
+                             if (tesTask.Value.State == TesState.CANCELEDEnum
                                 || tesTask.Value.State == TesState.COMPLETEEnum
                                 || tesTask.Value.State == TesState.EXECUTORERROREnum
                                 || tesTask.Value.State == TesState.SYSTEMERROREnum)


### PR DESCRIPTION
Using Blobxfer for file uploads since it handles the throttling and retries better than the built-in batch file upload functionality.
Removed the Job Preparation task that was handling the downloads and consolidated all execution (download/main/upload) to a single Batch task. 
Reduced polling frequency from 1 sec to 5 sec (this is how frequently TES checks the task status).
Fixes #59, #54