### PR TITLE
Deployer: handle no default Batch quota for test workflow

### DIFF
--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -36,6 +36,7 @@ namespace CromwellOnAzureDeployer
         public string CustomCromwellImagePath { get; set; }
         public string CustomTesImagePath { get; set; }
         public string CustomTriggerServiceImagePath { get; set; }
+        public bool RequireTestWorkflow { get; set; }
 
         public static Configuration BuildConfiguration(string[] args)
         {

--- a/src/deploy-cromwell-on-azure/test.wdl
+++ b/src/deploy-cromwell-on-azure/test.wdl
@@ -9,6 +9,7 @@ task hello {
   }
   runtime {
 	docker: 'ubuntu:16.04'
+    preemptible: true
   }
 }
 


### PR DESCRIPTION
Recently, Azure Batch changed their default core quota for some Azure subscriptions to 0.  As a result, when running the deployer, the test workflow would fail at the end of the deployment.  Even though the deployment was likely successful, it reports as failed, since the test workflow was not run.

This PR changes the functionality to the following:

- Test workflows will run as either a low-priority or dedicated VM if core quota is available
- If not available, the deployment will still succeed (exit code: 0), but a yellow warning message will appear which includes instructions for requesting quota and manually running a workflow
- If the argument "RequireTestWorkflow" is set to true, the deployment will fail if the test workflow is not run due to missing quota.  This is helpful for deployer integration tests to ensure a test workflow was actually executed.