### PR TITLE
Add top-most, parent workflow ID to every TesTask

### DIFF
--- a/src/TesApi.Tests/tesTaskExample.json
+++ b/src/TesApi.Tests/tesTaskExample.json
@@ -99,5 +99,6 @@
   "creation_time": "string",
   "error_count": 0,
   "is_cancel_requested": false,
-  "end_time": "string"
+  "end_time": "string",
+  "workflow_id": "string"
 }

--- a/src/TesApi.Web/ContractResolvers/BasicTesTaskContractResolver.cs
+++ b/src/TesApi.Web/ContractResolvers/BasicTesTaskContractResolver.cs
@@ -33,6 +33,7 @@ namespace TesApi.Web
                 Tuple.Create(typeof(TesTask), nameof(TesTask.IsCancelRequested)),
                 Tuple.Create(typeof(TesTask), nameof(TesTask.ErrorCount)),
                 Tuple.Create(typeof(TesTask), nameof(TesTask.EndTime)),
+                Tuple.Create(typeof(TesTask), nameof(TesTask.WorkflowId)),
                 Tuple.Create(typeof(TesResources), nameof(TesResources.VmInfo))
             };
 

--- a/src/TesApi.Web/ContractResolvers/FullTesTaskContractResolver.cs
+++ b/src/TesApi.Web/ContractResolvers/FullTesTaskContractResolver.cs
@@ -25,7 +25,8 @@ namespace TesApi.Web
                 Tuple.Create(typeof(TesTask), nameof(TesTask.IsCancelRequested)),
                 Tuple.Create(typeof(TesTask), nameof(TesTask.ErrorCount)),
                 Tuple.Create(typeof(TesTask), nameof(TesTask.EndTime)),
-                Tuple.Create(typeof(TesResources), nameof(TesResources.VmInfo))
+                Tuple.Create(typeof(TesTask), nameof(TesTask.WorkflowId)),
+                Tuple.Create(typeof(TesResources), nameof(TesResources.VmInfo)),
             };
 
         /// <summary>

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -121,7 +121,7 @@ namespace TesApi.Controllers
             // example: /cromwell-executions/test/daf1a044-d741-4db9-8eb5-d6fd0519b1f1/call-hello/execution/script
             tesTask.WorkflowId = tesTask
                 ?.Inputs
-                ?.FirstOrDefault(i => i.Path.StartsWith(rootExecutionPath, StringComparison.OrdinalIgnoreCase))
+                ?.FirstOrDefault(i => i?.Path?.StartsWith(rootExecutionPath, StringComparison.OrdinalIgnoreCase) == true)
                 ?.Path
                 ?.Split('/', StringSplitOptions.RemoveEmptyEntries)
                 ?.Skip(2)

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -20,8 +20,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Azure.Documents;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Annotations;

--- a/src/TesApi.Web/Models/TesTaskExtended.cs
+++ b/src/TesApi.Web/Models/TesTaskExtended.cs
@@ -25,5 +25,12 @@ namespace TesApi.Models
         /// <value>Date + time the task was completed, in RFC 3339 format. This is set by the system, not the client.</value>
         [DataMember(Name = "end_time")]
         public string EndTime { get; set; }
+
+
+        /// <summary>
+        /// Top-most parent workflow ID from the workflow engine
+        /// </summary>
+        [DataMember(Name = "workflow_id")]
+        public string WorkflowId { get; set; }
     }
 }


### PR DESCRIPTION
Adds the top-most, parent workflow ID from Cromwell to every child TesTask.  This is useful for being able to easily query CosmosDB for all TesTasks for a given workflow ID.

The code is based on the assumption that every TesTask has at least one input, which is the command script, and that the Cromwell workflow ID is present in path of the command script, in the form:

/cromwell-executions/test/**daf1a044-d741-4db9-8eb5-d6fd0519b1f1**/call-hello/execution/script

Example TesTask from Cosmos DB:

```
{
    "id": "caf1a066_7d90b8f4da194b62901ef56ea56d69a8",
    "state": "COMPLETE",
    "name": "test.hello",
    "description": "caf1a066-d799-4db9-8cc5-d6fd0519b1f0:BackendJobDescriptorKey_CommandCallNode_test.hello:-1:1",
    "inputs": [
        {
            "name": "commandScript",
            "description": "test.hello.commandScript",
            "url": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/script",
            "path": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/script",
            "type": "FILE",
            "content": null
        }
    ],
    "outputs": [
        {
            "name": "rc",
            "description": "test.hello.rc",
            "url": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/rc",
            "path": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/rc",
            "type": "FILE"
        },
        {
            "name": "stdout",
            "description": "test.hello.stdout",
            "url": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/stdout",
            "path": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/stdout",
            "type": "FILE"
        },
        {
            "name": "stderr",
            "description": "test.hello.stderr",
            "url": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/stderr",
            "path": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/stderr",
            "type": "FILE"
        },
        {
            "name": "commandScript",
            "description": "test.hello.commandScript",
            "url": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/script",
            "path": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/script",
            "type": "FILE"
        }
    ],
    "resources": {
        "cpu_cores": null,
        "preemptible": false,
        "ram_gb": null,
        "disk_gb": null,
        "zones": null,
        "vm_info": {
            "vm_size": "Standard_A1_v2",
            "vm_series": "Av2",
            "vm_low_priority": true,
            "vm_price_per_hour": 0.012,
            "vm_memory_in_gb": 2.048,
            "vm_number_of_cores": 1,
            "vm_resource_disk_size_in_gb": 10.24,
            "vm_max_data_disk_count": 2
        }
    },
    "executors": [
        {
            "image": "ubuntu@sha256:e60a002052d1a073f3212f3732cff8abc7997939c731850e6960eb94a244c406",
            "command": [
                "/bin/bash",
                "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/script"
            ],
            "workdir": null,
            "stdin": null,
            "stdout": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/stdout",
            "stderr": "/cromwell-executions/test/caf1a066-d799-4db9-8cc5-d6fd0519b1f0/call-hello/execution/stderr",
            "env": null
        }
    ],
    "volumes": null,
    "tags": null,
    "logs": null,
    "creation_time": "02/10/2020 17:00:12",
    "error_count": 0,
    "is_cancel_requested": false,
    "end_time": "2020-02-10T17:05:06.36+00:00",
    "workflow_id": "caf1a066-d799-4db9-8cc5-d6fd0519b1f0",
    "_partitionKey": "01",
    "_rid": "PPAdAImp40IBAAAAAAAAAA==",
    "_self": "dbs/PPAdAA==/colls/PPAdAImp40I=/docs/PPAdAImp40IBAAAAAAAAAA==/",
    "_etag": "\"0000dd1c-0000-0b00-0000-5e418d420000\"",
    "_attachments": "attachments/",
    "_ts": 1581354306
}
```