### PR TITLE
Add CachingAzureProxy to cache Azure resources

### DIFF
--- a/src/TesApi.Tests/CachingAzureProxyTests.cs
+++ b/src/TesApi.Tests/CachingAzureProxyTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using TesApi.Models;
+using TesApi.Web;
+
+namespace TesApi.Tests
+{
+    [TestClass]
+    public class CachingAzureProxyTests
+    {
+        [TestMethod]
+        public async Task GetBatchAccountQuotasAsync_UsesCache()
+        {
+            var azureProxy = GetMockAzureProxy();
+            var batchQuotas = new AzureProxy.AzureBatchAccountQuotas { ActiveJobAndJobScheduleQuota = 1, PoolQuota = 1, DedicatedCoreQuota = 5, LowPriorityCoreQuota = 10 };
+            azureProxy.Setup(a => a.GetBatchAccountQuotasAsync()).Returns(Task.FromResult(batchQuotas));
+            var cachingAzureProxy = new CachingAzureProxy(azureProxy.Object, new Mock<ILogger<CachingAzureProxy>>().Object);
+
+            var quotas1 = await cachingAzureProxy.GetBatchAccountQuotasAsync();
+            var quotas2 = await cachingAzureProxy.GetBatchAccountQuotasAsync();
+
+            azureProxy.Verify(mock => mock.GetBatchAccountQuotasAsync(), Times.Once());
+            Assert.AreEqual(batchQuotas, quotas1);
+            Assert.AreEqual(quotas1, quotas2);
+        }
+
+        [TestMethod]
+        public async Task GetStorageAccountKeyAsync_UsesCache()
+        {
+            var azureProxy = GetMockAzureProxy();
+            var storageAccountInfo = new StorageAccountInfo { Name = "defaultstorageaccount", Id = "Id", BlobEndpoint = "https://defaultstorageaccount/", SubscriptionId = "SubId" };
+            var storageAccountKey = "key";
+            azureProxy.Setup(a => a.GetStorageAccountKeyAsync(It.IsAny<StorageAccountInfo>())).Returns(Task.FromResult(storageAccountKey));
+            var cachingAzureProxy = new CachingAzureProxy(azureProxy.Object, new Mock<ILogger<CachingAzureProxy>>().Object);
+
+            var key1 = await cachingAzureProxy.GetStorageAccountKeyAsync(storageAccountInfo);
+            var key2 = await cachingAzureProxy.GetStorageAccountKeyAsync(storageAccountInfo);
+
+            azureProxy.Verify(mock => mock.GetStorageAccountKeyAsync(storageAccountInfo), Times.Once());
+            Assert.AreEqual(storageAccountKey, key1);
+            Assert.AreEqual(key1, key2);
+        }
+
+        [TestMethod]
+        public async Task GetVMSizesAndPricesAsync_UsesCache_CalledFromConstructor()
+        {
+            var azureProxy = GetMockAzureProxy();
+            var cachingAzureProxy = new CachingAzureProxy(azureProxy.Object, new Mock<ILogger<CachingAzureProxy>>().Object);
+
+            var vmSizesAndPrices1 = await cachingAzureProxy.GetVmSizesAndPricesAsync();
+            var vmSizesAndPrices2 = await cachingAzureProxy.GetVmSizesAndPricesAsync();
+
+            azureProxy.Verify(mock => mock.GetVmSizesAndPricesAsync(), Times.Once());
+            Assert.AreEqual(vmSizesAndPrices1, vmSizesAndPrices2);
+            Assert.AreEqual(4, vmSizesAndPrices1.Count);
+        }
+
+        [TestMethod]
+        public async Task GetStorageAccountInfoAsync_UsesCache()
+        {
+            var azureProxy = GetMockAzureProxy();
+            var storageAccountInfo = new StorageAccountInfo { Name = "defaultstorageaccount", Id = "Id", BlobEndpoint = "https://defaultstorageaccount/", SubscriptionId = "SubId" };
+
+            azureProxy.Setup(a => a.GetStorageAccountInfoAsync(It.IsAny<string>())).Returns(Task.FromResult(storageAccountInfo));
+            var cachingAzureProxy = new CachingAzureProxy(azureProxy.Object, new Mock<ILogger<CachingAzureProxy>>().Object);
+
+            var info1 = await cachingAzureProxy.GetStorageAccountInfoAsync("defaultstorageaccount");
+            var info2 = await cachingAzureProxy.GetStorageAccountInfoAsync("defaultstorageaccount");
+
+            azureProxy.Verify(mock => mock.GetStorageAccountInfoAsync("defaultstorageaccount"), Times.Once());
+            Assert.AreEqual(storageAccountInfo, info1);
+            Assert.AreEqual(info1, info2);
+        }
+
+        [TestMethod]
+        public async Task GetStorageAccountInfoAsync_UsesCache_NullInfo_DoesNotSetCache()
+        {
+            var azureProxy = GetMockAzureProxy();
+
+            azureProxy.Setup(a => a.GetStorageAccountInfoAsync(It.IsAny<string>())).Returns(Task.FromResult((StorageAccountInfo)null));
+            var cachingAzureProxy = new CachingAzureProxy(azureProxy.Object, new Mock<ILogger<CachingAzureProxy>>().Object);
+            var info1 = await cachingAzureProxy.GetStorageAccountInfoAsync("defaultstorageaccount");
+
+            var storageAccountInfo = new StorageAccountInfo { Name = "defaultstorageaccount", Id = "Id", BlobEndpoint = "https://defaultstorageaccount/", SubscriptionId = "SubId" };
+            azureProxy.Setup(a => a.GetStorageAccountInfoAsync(It.IsAny<string>())).Returns(Task.FromResult(storageAccountInfo));
+            var info2 = await cachingAzureProxy.GetStorageAccountInfoAsync("defaultstorageaccount");
+
+            azureProxy.Verify(mock => mock.GetStorageAccountInfoAsync("defaultstorageaccount"), Times.Exactly(2));
+            Assert.IsNull(info1);
+            Assert.AreEqual(storageAccountInfo, info2);
+        }
+
+        [TestMethod]
+        public async Task GetContainerRegistryInfoAsync_UsesCache()
+        {
+            var azureProxy = GetMockAzureProxy();
+            var containerRegistryInfo = new ContainerRegistryInfo { RegistryServer = "registryServer1", Username = "default", Password = "placeholder" };
+
+            azureProxy.Setup(a => a.GetContainerRegistryInfoAsync(It.IsAny<string>())).Returns(Task.FromResult(containerRegistryInfo));
+            var cachingAzureProxy = new CachingAzureProxy(azureProxy.Object, new Mock<ILogger<CachingAzureProxy>>().Object);
+
+            var info1 = await cachingAzureProxy.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1");
+            var info2 = await cachingAzureProxy.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1");
+
+            azureProxy.Verify(mock => mock.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1"), Times.Once());
+            Assert.AreEqual(containerRegistryInfo, info1);
+            Assert.AreEqual(info1, info2);
+        }
+
+        [TestMethod]
+        public async Task GetContainerRegistryInfoAsync_UsesCache_NullInfo_DoesNotSetCache()
+        {
+            var azureProxy = GetMockAzureProxy();
+
+            azureProxy.Setup(a => a.GetContainerRegistryInfoAsync(It.IsAny<string>())).Returns(Task.FromResult((ContainerRegistryInfo)null));
+            var cachingAzureProxy = new CachingAzureProxy(azureProxy.Object, new Mock<ILogger<CachingAzureProxy>>().Object);
+            var info1 = await cachingAzureProxy.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1");
+
+            var containerRegistryInfo = new ContainerRegistryInfo { RegistryServer = "registryServer1", Username = "default", Password = "placeholder" };
+            azureProxy.Setup(a => a.GetContainerRegistryInfoAsync(It.IsAny<string>())).Returns(Task.FromResult(containerRegistryInfo));
+            var info2 = await cachingAzureProxy.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1");
+
+            azureProxy.Verify(mock => mock.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1"), Times.Exactly(2));
+            Assert.IsNull(info1);
+            Assert.AreEqual(containerRegistryInfo, info2);
+        }
+
+        private Mock<IAzureProxy> GetMockAzureProxy()
+        {
+            var azureProxy = new Mock<IAzureProxy>();
+
+            azureProxy.Setup(a => a.GetVmSizesAndPricesAsync()).Returns(Task.FromResult(
+                new List<VirtualMachineInfo> {
+                    new VirtualMachineInfo { VmSize = "VmSizeLowPri1", LowPriority = true, NumberOfCores = 1, MemoryInGB = 4, ResourceDiskSizeInGB = 20, PricePerHour = 1 },
+                    new VirtualMachineInfo { VmSize = "VmSizeLowPri2", LowPriority = true, NumberOfCores = 2, MemoryInGB = 8, ResourceDiskSizeInGB = 40, PricePerHour = 2 },
+                    new VirtualMachineInfo { VmSize = "VmSizeDedicated1", LowPriority = false, NumberOfCores = 1, MemoryInGB = 4, ResourceDiskSizeInGB = 20, PricePerHour = 11 },
+                    new VirtualMachineInfo { VmSize = "VmSizeDedicated2", LowPriority = false, NumberOfCores = 2, MemoryInGB = 8, ResourceDiskSizeInGB = 40, PricePerHour = 22 }
+                }));
+
+            return azureProxy;
+        }
+    }
+}

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -51,11 +51,11 @@ namespace TesApi.Web
         /// </summary>
         /// <param name="logger">Logger instance provided by ASP.NET Core DI</param>
         /// <param name="configuration">Configuration</param>
-        /// <param name="cachingAzureProxy">Azure proxy</param>
-        public BatchScheduler(ILogger logger, IConfiguration configuration, IAzureProxy cachingAzureProxy)
+        /// <param name="azureProxy">Azure proxy</param>
+        public BatchScheduler(ILogger logger, IConfiguration configuration, IAzureProxy azureProxy)
         {
             this.logger = logger;
-            this.azureProxy = cachingAzureProxy;
+            this.azureProxy = azureProxy;
 
             defaultStorageAccountName = configuration["DefaultStorageAccountName"];    // This account contains the cromwell-executions container
             usePreemptibleVmsOnly = bool.TryParse(configuration["UsePreemptibleVmsOnly"], out var temp) ? temp : false;

--- a/src/TesApi.Web/CachingAzureProxy.cs
+++ b/src/TesApi.Web/CachingAzureProxy.cs
@@ -122,7 +122,7 @@ namespace TesApi.Web
             {
                 // retry
                 var vmSizesAndPrices = await azureProxy.GetVmSizesAndPricesAsync();
-                cache.Set(key, vmSizesAndPrices.ToList(), DateTimeOffset.MaxValue);
+                cache.Set(key, vmSizesAndPrices.ToList(), TimeSpan.FromDays(1));
             }
 
             return cachedVmSizesAndPrices;

--- a/src/TesApi.Web/CachingAzureProxy.cs
+++ b/src/TesApi.Web/CachingAzureProxy.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Batch;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using TesApi.Models;
+using static TesApi.Web.AzureProxy;
+
+namespace TesApi.Web
+{
+    ///<inheritdoc/>
+    /// <summary>
+    /// Implements caching for <see cref="IAzureProxy"/>.
+    /// </summary>
+    public class CachingAzureProxy : IAzureProxy
+    {
+        private readonly IAzureProxy azureProxy;
+        private readonly ILogger<CachingAzureProxy> logger;
+
+        private MemoryCache cache { get; set; } = new MemoryCache(new MemoryCacheOptions());
+
+        /// <summary>
+        /// Contructor to create a cache of <see cref="IAzureProxy"/>
+        /// </summary>
+        /// <param name="azureProxy"></param>
+        /// <param name="logger"></param>
+        public CachingAzureProxy(IAzureProxy azureProxy, ILogger<CachingAzureProxy> logger)
+        {
+            this.azureProxy = azureProxy;
+            this.logger = logger;
+            GetVmSizesAndPricesAsync().Wait();
+        }
+
+        public Task CreateBatchJobAsync(string jobId, CloudTask cloudTask, PoolInformation poolInformation) => azureProxy.CreateBatchJobAsync(jobId, cloudTask, poolInformation);
+        public Task DeleteBatchJobAsync(string taskId) => azureProxy.DeleteBatchJobAsync(taskId);
+        public Task DeleteBatchPoolAsync(string poolId, CancellationToken cancellationToken) => azureProxy.DeleteBatchPoolAsync(poolId, cancellationToken);
+        public Task<string> DownloadBlobAsync(Uri blobAbsoluteUri) => azureProxy.DownloadBlobAsync(blobAbsoluteUri);
+        public Task<IEnumerable<string>> GetActivePoolIdsAsync(string prefix, TimeSpan minAge, CancellationToken cancellationToken) => azureProxy.GetActivePoolIdsAsync(prefix, minAge, cancellationToken);
+
+        ///<inheritdoc/>
+        public async Task<AzureBatchAccountQuotas> GetBatchAccountQuotasAsync()
+        {
+            const string key = "batchAccountQuotas";
+
+            if (!cache.TryGetValue(key, out AzureBatchAccountQuotas azureBatchAccountQuotas))
+            {
+                // retry
+                var batchAccountQuotas = await azureProxy.GetBatchAccountQuotasAsync();
+                return cache.Set(key, batchAccountQuotas, TimeSpan.FromHours(1));
+            }
+
+            return azureBatchAccountQuotas;
+        }
+
+        public int GetBatchActiveJobCount() => azureProxy.GetBatchActiveJobCount();
+        public IEnumerable<AzureProxy.AzureBatchNodeCount> GetBatchActiveNodeCountByVmSize() => azureProxy.GetBatchActiveNodeCountByVmSize();
+        public int GetBatchActivePoolCount() => azureProxy.GetBatchActivePoolCount();
+        public Task<AzureProxy.AzureBatchJobAndTaskState> GetBatchJobAndTaskStateAsync(string tesTaskId) => azureProxy.GetBatchJobAndTaskStateAsync(tesTaskId);
+
+        ///<inheritdoc/>
+        public async Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName)
+        {
+            if (!cache.TryGetValue(imageName, out ContainerRegistryInfo containerRegistry))
+            {
+                // retry
+                containerRegistry = await azureProxy.GetContainerRegistryInfoAsync(imageName);
+
+                if (containerRegistry != null)
+                {
+                    cache.Set(imageName, containerRegistry, TimeSpan.FromHours(1));
+                }
+            }
+
+            return containerRegistry;
+        }
+
+        public Task<string> GetNextBatchJobIdAsync(string tesTaskId) => azureProxy.GetNextBatchJobIdAsync(tesTaskId);
+        public Task<IEnumerable<string>> GetPoolIdsReferencedByJobsAsync(CancellationToken cancellationToken) => azureProxy.GetPoolIdsReferencedByJobsAsync(cancellationToken);
+
+        ///<inheritdoc/>
+        public async Task<string> GetStorageAccountKeyAsync(StorageAccountInfo storageAccountInfo)
+        {
+            if (!cache.TryGetValue(storageAccountInfo.Id, out string accountKey))
+            {
+                // retry
+                accountKey = await azureProxy.GetStorageAccountKeyAsync(storageAccountInfo);
+                cache.Set(storageAccountInfo.Id, accountKey, TimeSpan.FromHours(1));
+            }
+
+            return accountKey;
+        }
+
+        ///<inheritdoc/>
+        public async Task<StorageAccountInfo> GetStorageAccountInfoAsync(string storageAccountName)
+        {
+            if (!cache.TryGetValue(storageAccountName, out StorageAccountInfo storageAccountInfo))
+            {
+                // retry
+                storageAccountInfo = await azureProxy.GetStorageAccountInfoAsync(storageAccountName);
+
+                if (storageAccountInfo != null)
+                {
+                    cache.Set(storageAccountName, storageAccountInfo, DateTimeOffset.MaxValue);
+                }
+            }
+
+            return storageAccountInfo;
+        }
+
+        ///<inheritdoc/>
+        public async Task<List<VirtualMachineInfo>> GetVmSizesAndPricesAsync()
+        {
+            const string key = "vmSizesAndPrices";
+
+            if (!cache.TryGetValue(key, out List<VirtualMachineInfo> cachedVmSizesAndPrices))
+            {
+                // retry
+                var vmSizesAndPrices = await azureProxy.GetVmSizesAndPricesAsync();
+                cache.Set(key, vmSizesAndPrices.ToList(), DateTimeOffset.MaxValue);
+            }
+
+            return cachedVmSizesAndPrices;
+        }
+
+        public Task<IEnumerable<string>> ListBlobsAsync(Uri directoryUri) => azureProxy.ListBlobsAsync(directoryUri);
+        public Task<IEnumerable<string>> ListOldJobsToDeleteAsync(TimeSpan oldestJobAge) => azureProxy.ListOldJobsToDeleteAsync(oldestJobAge);
+        public Task UploadBlobAsync(Uri blobAbsoluteUri, string content) => azureProxy.UploadBlobAsync(blobAbsoluteUri, content);
+        public Task<(Uri, string)> GetCosmosDbEndpointAndKeyAsync(string cosmosDbAccountName) => azureProxy.GetCosmosDbEndpointAndKeyAsync(cosmosDbAccountName);
+    }
+}

--- a/src/TesApi.Web/IAzureProxy.cs
+++ b/src/TesApi.Web/IAzureProxy.cs
@@ -40,9 +40,9 @@ namespace TesApi.Web
         Task CreateBatchJobAsync(string jobId, CloudTask cloudTask, PoolInformation poolInformation);
 
         /// <summary>
-        /// Gets the <see cref="ContainerRegistryInfo"/> for the given registry name
+        /// Gets the <see cref="ContainerRegistryInfo"/> for the given image name
         /// </summary>
-        /// <param name="imageName">Executor image name</param>
+        /// <param name="imageName">Image name</param>
         /// <returns><see cref="ContainerRegistryInfo"/></returns>
         Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName);
 

--- a/src/TesApi.Web/IAzureProxy.cs
+++ b/src/TesApi.Web/IAzureProxy.cs
@@ -22,7 +22,7 @@ namespace TesApi.Web
         /// </summary>
         /// <param name="cosmosDbAccountName"></param>
         /// <returns>The CosmosDB endpoint and key of the specified account</returns>
-        Task<(Uri, string)> GetCosmosDbEndpointAndKey(string cosmosDbAccountName);
+        Task<(Uri, string)> GetCosmosDbEndpointAndKeyAsync(string cosmosDbAccountName);
 
         /// <summary>
         /// Gets a new Azure Batch job id to schedule another task
@@ -40,10 +40,18 @@ namespace TesApi.Web
         Task CreateBatchJobAsync(string jobId, CloudTask cloudTask, PoolInformation poolInformation);
 
         /// <summary>
-        /// Retrieves the list of container registries that the TES server has access to.
+        /// Gets the <see cref="ContainerRegistryInfo"/> for the given registry name
         /// </summary>
-        /// <returns>List of container registries</returns>
-        Task<IEnumerable<ContainerRegistryInfo>> GetAccessibleContainerRegistriesAsync();
+        /// <param name="imageName">Executor image name</param>
+        /// <returns><see cref="ContainerRegistryInfo"/></returns>
+        Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName);
+
+        /// <summary>
+        /// Gets the <see cref="StorageAccountInfo"/> for the given storage account name
+        /// </summary>
+        /// <param name="storageAccountName">Storage account name</param>
+        /// <returns><see cref="StorageAccountInfo"/></returns>
+        Task<StorageAccountInfo> GetStorageAccountInfoAsync(string storageAccountName);
 
         /// <summary>
         /// Get the current states of the Azure Batch job and task corresponding to the given TES task
@@ -61,7 +69,7 @@ namespace TesApi.Web
         /// <summary>
         /// Get Batch account quota
         /// </summary>
-        /// <returns></returns>
+        /// <returns><see cref="AzureBatchAccountQuotas"/></returns>
         Task<AzureBatchAccountQuotas> GetBatchAccountQuotasAsync();
 
         /// <summary>
@@ -87,12 +95,6 @@ namespace TesApi.Web
         /// </summary>
         /// <returns><see cref="VirtualMachineInfo"/> for available VMs in a region.</returns>
         Task<List<VirtualMachineInfo>> GetVmSizesAndPricesAsync();
-
-        /// <summary>
-        /// Gets the list of storage accounts that the TES server has access to
-        /// </summary>
-        /// <returns>List of storage accounts</returns>
-        Task<IEnumerable<StorageAccountInfo>> GetAccessibleStorageAccountsAsync();
 
         /// <summary>
         /// Gets the primary key of the given storage account.


### PR DESCRIPTION
This PR adds caching for Azure resources:

1. VM sizes and prices
2. Batch account quotas
3. Container registry info
4. Storage account info
5. Storage account key

Please expand `BatchScheduler.cs` class to load the diff

Addresses #38 and https://github.com/microsoft/CromwellOnAzure/issues/36#issuecomment-614286357

Next steps: Add retries #76 and handle all exceptions from TES server gracefully #36 

