### PR TITLE
Add caching and retries for CosmosDbRepository

### DIFF
--- a/src/TesApi.Tests/CachingAzureProxyTests.cs
+++ b/src/TesApi.Tests/CachingAzureProxyTests.cs
@@ -54,7 +54,7 @@ namespace TesApi.Tests
         }
 
         [TestMethod]
-        public async Task GetVMSizesAndPricesAsync_UsesCache_CalledFromConstructor()
+        public async Task GetVMSizesAndPricesAsync_UsesCache()
         {
             var azureProxy = GetMockAzureProxy();
             var cachingAzureProxy = new CachingAzureProxy(azureProxy.Object, cache, new Mock<ILogger<CachingAzureProxy>>().Object);
@@ -85,7 +85,7 @@ namespace TesApi.Tests
         }
 
         [TestMethod]
-        public async Task GetStorageAccountInfoAsync_UsesCache_NullInfo_DoesNotSetCache()
+        public async Task GetStorageAccountInfoAsync_NullInfo_DoesNotSetCache()
         {
             var azureProxy = GetMockAzureProxy();
 
@@ -120,7 +120,7 @@ namespace TesApi.Tests
         }
 
         [TestMethod]
-        public async Task GetContainerRegistryInfoAsync_UsesCache_NullInfo_DoesNotSetCache()
+        public async Task GetContainerRegistryInfoAsync_NullInfo_DoesNotSetCache()
         {
             var azureProxy = GetMockAzureProxy();
 

--- a/src/TesApi.Tests/CachingWithRetriesRepositoryTests.cs
+++ b/src/TesApi.Tests/CachingWithRetriesRepositoryTests.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Polly.Utilities;
+using TesApi.Models;
+using TesApi.Web;
+
+namespace TesApi.Tests
+{
+    [TestClass]
+    public class CachingWithRetriesRepositoryTests
+    {
+        [TestMethod]
+        public async Task CreateItemAsync_ClearsAllItemsPredicateCacheKeys()
+        {
+            var repository = GetMockRepository();
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            var tesTask = new TesTask { Id = "createItem", State = TesState.QUEUEDEnum };
+            Expression<Func<TesTask, bool>> predicate = t => t.State == TesState.QUEUEDEnum
+                       || t.State == TesState.INITIALIZINGEnum
+                       || t.State == TesState.RUNNINGEnum
+                       || (t.State == TesState.CANCELEDEnum && t.IsCancelRequested);
+
+            var items = await cachingRepository.GetItemsAsync(predicate);
+            await cachingRepository.CreateItemAsync(tesTask);
+            var items2 = await cachingRepository.GetItemsAsync(predicate);
+
+            repository.Verify(mock => mock.GetItemsAsync(It.IsAny<Expression<Func<TesTask, bool>>>()), Times.Exactly(2));
+            repository.Verify(mock => mock.CreateItemAsync(It.IsAny<TesTask>()), Times.Once());
+            Assert.AreEqual(items, items2);
+        }
+
+        [TestMethod]
+        public async Task DeleteItemAsync_ClearsAllItemsPredicateCacheKeys()
+        {
+            var repository = GetMockRepository();
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            Expression<Func<TesTask, bool>> predicate = t => t.State == TesState.QUEUEDEnum
+                       || t.State == TesState.INITIALIZINGEnum
+                       || t.State == TesState.RUNNINGEnum
+                       || (t.State == TesState.CANCELEDEnum && t.IsCancelRequested);
+
+            var items = await cachingRepository.GetItemsAsync(predicate);
+            await cachingRepository.DeleteItemAsync("deleteItem");
+            var items2 = await cachingRepository.GetItemsAsync(predicate);
+
+            repository.Verify(mock => mock.GetItemsAsync(It.IsAny<Expression<Func<TesTask, bool>>>()), Times.Exactly(2));
+            repository.Verify(mock => mock.DeleteItemAsync(It.IsAny<string>()), Times.Once());
+            Assert.AreEqual(items, items2);
+        }
+
+        [TestMethod]
+        public async Task DeleteItemAsync_RemovesItemFromCache()
+        {
+            var repository = GetMockRepository();
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            RepositoryItem<TesTask> repositoryItem = null;
+            Action<RepositoryItem<TesTask>> action = item => repositoryItem = item;
+
+            var success = await cachingRepository.TryGetItemAsync("tesTask1", action);
+            await cachingRepository.DeleteItemAsync("tesTask1");
+            var success2 = await cachingRepository.TryGetItemAsync("tesTask1", action);
+
+            repository.Verify(mock => mock.TryGetItemAsync("tesTask1", It.IsAny<Action<RepositoryItem<TesTask>>>()), Times.Exactly(2));
+            repository.Verify(mock => mock.DeleteItemAsync("tesTask1"), Times.Once());
+            Assert.AreEqual(success, success2);
+        }
+
+        [TestMethod]
+        public async Task UpdateItemAsync_ClearsAllItemsPredicateCacheKeys()
+        {
+            var repository = GetMockRepository();
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            RepositoryItem<TesTask> repositoryItem = null;
+            Expression<Func<TesTask, bool>> predicate = t => t.State == TesState.QUEUEDEnum
+                       || t.State == TesState.INITIALIZINGEnum
+                       || t.State == TesState.RUNNINGEnum
+                       || (t.State == TesState.CANCELEDEnum && t.IsCancelRequested);
+
+            var items = await cachingRepository.GetItemsAsync(predicate);
+            await cachingRepository.UpdateItemAsync("updateItem", repositoryItem);
+            var items2 = await cachingRepository.GetItemsAsync(predicate);
+
+            repository.Verify(mock => mock.GetItemsAsync(It.IsAny<Expression<Func<TesTask, bool>>>()), Times.Exactly(2));
+            repository.Verify(mock => mock.UpdateItemAsync(It.IsAny<string>(), It.IsAny<RepositoryItem<TesTask>>()), Times.Once());
+            Assert.AreEqual(items, items2);
+        }
+
+        [TestMethod]
+        public async Task UpdateItemAsync_RemovesItemFromCache()
+        {
+            var repository = GetMockRepository();
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            RepositoryItem<TesTask> repositoryItem = null;
+            Action<RepositoryItem<TesTask>> action = item => repositoryItem = item;
+
+            var success = await cachingRepository.TryGetItemAsync("tesTask1", action);
+            await cachingRepository.UpdateItemAsync("tesTask1", repositoryItem);
+            var success2 = await cachingRepository.TryGetItemAsync("tesTask1", action);
+
+            repository.Verify(mock => mock.TryGetItemAsync("tesTask1", It.IsAny<Action<RepositoryItem<TesTask>>>()), Times.Exactly(2));
+            repository.Verify(mock => mock.UpdateItemAsync(It.IsAny<string>(), It.IsAny<RepositoryItem<TesTask>>()), Times.Once());
+            Assert.AreEqual(success, success2);
+        }
+
+        [TestMethod]
+        public async Task GetItemsAsync_UsesCache()
+        {
+            var repository = GetMockRepository();
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            Expression<Func<TesTask, bool>> predicate = t => t.State == TesState.QUEUEDEnum
+                       || t.State == TesState.INITIALIZINGEnum
+                       || t.State == TesState.RUNNINGEnum
+                       || (t.State == TesState.CANCELEDEnum && t.IsCancelRequested);
+
+            var items = await cachingRepository.GetItemsAsync(predicate);
+            var items2 = await cachingRepository.GetItemsAsync(predicate);
+
+            repository.Verify(mock => mock.GetItemsAsync(It.IsAny<Expression<Func<TesTask, bool>>>()), Times.Once());
+            Assert.AreEqual(items, items2);
+            Assert.AreEqual(3, items.Count());
+        }
+
+        [TestMethod]
+        public async Task GetItemsAsync_ThrowsException_DoesNotSetCache()
+        {
+            SystemClock.SleepAsync = (_, __) => Task.FromResult(true);
+            SystemClock.Sleep = (_, __) => { };
+            var repository = GetMockRepository();
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            Expression<Func<TesTask, bool>> predicate = t => t.WorkflowId.Equals("doesNotExist");
+
+            await Assert.ThrowsExceptionAsync<Exception>(async () => await cachingRepository.GetItemsAsync(predicate));
+            repository.Verify(mock => mock.GetItemsAsync(predicate), Times.Exactly(4));
+        }
+
+        [TestMethod]
+        public async Task TryGetItemAsync_UsesCache()
+        {
+            var repository = GetMockRepository();
+            RepositoryItem<TesTask> repositoryItem = null;
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            Action<RepositoryItem<TesTask>> action = item => repositoryItem = item;
+
+            var success = await cachingRepository.TryGetItemAsync("tesTask1", action);
+            var success2 = await cachingRepository.TryGetItemAsync("tesTask1", action);
+
+            repository.Verify(mock => mock.TryGetItemAsync("tesTask1", It.IsAny<Action<RepositoryItem<TesTask>>>()), Times.Once());
+            Assert.IsTrue(success);
+            Assert.IsTrue(success2);
+        }
+
+        [TestMethod]
+        public async Task TryGetItemAsync_IfItemNotFound_DoesNotSetCache()
+        {
+            var repository = GetMockRepository();
+            RepositoryItem<TesTask> repositoryItem = null;
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            Action<RepositoryItem<TesTask>> action = item => repositoryItem = item;
+
+            var success = await cachingRepository.TryGetItemAsync("notFound", action);
+            var success2 = await cachingRepository.TryGetItemAsync("notFound", action);
+
+            repository.Verify(mock => mock.TryGetItemAsync("notFound", It.IsAny<Action<RepositoryItem<TesTask>>>()), Times.Exactly(2));
+            Assert.IsFalse(success);
+            Assert.IsFalse(success2);
+        }
+
+        [TestMethod]
+        public async Task TryGetItemAsync_ThrowsException_DoesNotSetCache()
+        {
+            SystemClock.SleepAsync = (_, __) => Task.FromResult(true);
+            SystemClock.Sleep = (_, __) => { };
+            var repository = GetMockRepository();
+            RepositoryItem<TesTask> repositoryItem = null;
+            var cachingRepository = new CachingWithRetriesRepository<TesTask>(repository.Object);
+            Action<RepositoryItem<TesTask>> action = item => repositoryItem = item;
+
+            await Assert.ThrowsExceptionAsync<Exception>(async () => await cachingRepository.TryGetItemAsync("throws", action));
+            repository.Verify(mock => mock.TryGetItemAsync("throws", It.IsAny<Action<RepositoryItem<TesTask>>>()), Times.Exactly(4));
+        }
+
+        private Mock<IRepository<TesTask>> GetMockRepository()
+        {
+            var repository = new Mock<IRepository<TesTask>>();
+            var tasks = new List<TesTask>()
+            {
+                new TesTask { Id = "tesTaskId1", State = TesState.QUEUEDEnum },
+                new TesTask { Id = "tesTaskId2", State = TesState.INITIALIZINGEnum },
+                new TesTask { Id = "tesTaskId3", State = TesState.RUNNINGEnum },
+            };
+
+            var repositoryItems = tasks.Select(
+                t => new RepositoryItem<TesTask> { ETag = Guid.NewGuid().ToString(), Value = t });
+
+            repository.Setup(a => a.GetItemsAsync(It.IsAny<Expression<Func<TesTask, bool>>>()))
+                .Returns(Task.FromResult(repositoryItems));
+            repository.Setup(a => a.GetItemsAsync(t => t.WorkflowId.Equals("doesNotExist")))
+                .Throws(new Exception());
+
+            repository.Setup(a => a.TryGetItemAsync("tesTask1", It.IsAny<Action<RepositoryItem<TesTask>>>()))
+                .Returns(Task.FromResult(true));
+            repository.Setup(a => a.TryGetItemAsync("notFound", It.IsAny<Action<RepositoryItem<TesTask>>>()))
+                .Returns(Task.FromResult(false));
+            repository.Setup(a => a.TryGetItemAsync("throws", It.IsAny<Action<RepositoryItem<TesTask>>>()))
+                .Throws(new Exception());
+
+            return repository;
+        }
+
+    }
+}

--- a/src/TesApi.Web/CachingAzureProxy.cs
+++ b/src/TesApi.Web/CachingAzureProxy.cs
@@ -7,9 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using LazyCache;
 using Microsoft.Azure.Batch;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using TesApi.Models;
 using static TesApi.Web.AzureProxy;
 

--- a/src/TesApi.Web/CachingWithRetriesRepository.cs
+++ b/src/TesApi.Web/CachingWithRetriesRepository.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
+
+namespace TesApi.Web
+{
+    ///<inheritdoc/>
+    /// <summary>
+    /// Implements caching and retries for <see cref="IRepository{T}"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class CachingWithRetriesRepository<T> : IRepository<T> where T : class
+    {
+        private readonly IRepository<T> repository;
+
+        private readonly IMemoryCache cache = new MemoryCache(new MemoryCacheOptions());
+        private readonly IList<object> itemsPredicateCachedKeys = new List<object>();
+
+        private readonly AsyncRetryPolicy retryPolicy = Policy
+                .Handle<Exception>()
+                .WaitAndRetryAsync(3, attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
+
+        /// <summary>
+        /// Constructor to create a cache and retry wrapper for <see cref="IRepository{T}"/>
+        /// </summary>
+        /// <param name="repository"><see cref="IRepository{T}"/> to wrap with caching and retries</param>
+        public CachingWithRetriesRepository(IRepository<T> repository)
+        {
+            this.repository = repository;
+        }
+
+        ///<inheritdoc/>
+        public Task<RepositoryItem<T>> CreateItemAsync(T item)
+        {
+            ClearAllItemsPredicateCachedKeys();
+            return retryPolicy.ExecuteAsync(() => repository.CreateItemAsync(item));
+        }
+
+        ///<inheritdoc/>
+        public Task DeleteItemAsync(string id)
+        {
+            if (cache.TryGetValue(id, out var cachedRepositoryItem))
+            {
+                cache.Remove(id);
+            }
+
+            ClearAllItemsPredicateCachedKeys();
+            return retryPolicy.ExecuteAsync(() => repository.DeleteItemAsync(id));
+        }
+
+        ///<inheritdoc/>
+        public async Task<bool> TryGetItemAsync(string id, Action<RepositoryItem<T>> onSuccess)
+        {
+            RepositoryItem<T> repositoryItem = null;
+
+            if (cache.TryGetValue(id, out repositoryItem))
+            {
+                onSuccess(repositoryItem);
+                return true;
+            }
+
+            var repositoryItemFound = await retryPolicy.ExecuteAsync(() => repository.TryGetItemAsync(id, item => repositoryItem = item));
+
+            if (repositoryItemFound)
+            {
+                cache.Set(id, repositoryItem, TimeSpan.FromMinutes(5));
+                onSuccess(repositoryItem);
+            }
+
+            return repositoryItemFound;
+        }
+
+        ///<inheritdoc/>
+        public Task<(string, IEnumerable<RepositoryItem<T>>)> GetItemsAsync(Expression<Func<T, bool>> predicate, int pageSize, string continuationToken)
+            => retryPolicy.ExecuteAsync(() => repository.GetItemsAsync(predicate, pageSize, continuationToken));
+
+        ///<inheritdoc/>
+        public async Task<IEnumerable<RepositoryItem<T>>> GetItemsAsync(Expression<Func<T, bool>> predicate)
+        {
+            var key = predicate.ToString().GetHashCode();
+            IEnumerable<RepositoryItem<T>> repositoryItems = new List<RepositoryItem<T>>();
+
+            if (cache.TryGetValue(key, out repositoryItems))
+            {
+                return repositoryItems;
+            }
+
+            repositoryItems = await retryPolicy.ExecuteAsync(() => repository.GetItemsAsync(predicate));
+            itemsPredicateCachedKeys.Add(key);
+            return cache.Set(key, repositoryItems, DateTimeOffset.MaxValue);
+        }
+
+        ///<inheritdoc/>
+        public Task<RepositoryItem<T>> UpdateItemAsync(string id, RepositoryItem<T> item)
+        {
+            if (cache.TryGetValue(id, out var cachedRepositoryItem))
+            {
+                cache.Remove(id);
+            }
+
+            ClearAllItemsPredicateCachedKeys();
+            return retryPolicy.ExecuteAsync(() => repository.UpdateItemAsync(id, item));
+        }
+
+        private void ClearAllItemsPredicateCachedKeys()
+        {
+            foreach (var key in itemsPredicateCachedKeys)
+            {
+                cache.Remove(key);
+            }
+
+            itemsPredicateCachedKeys.Clear();
+        }
+    }
+}

--- a/src/TesApi.Web/CachingWithRetriesRepository.cs
+++ b/src/TesApi.Web/CachingWithRetriesRepository.cs
@@ -34,25 +34,23 @@ namespace TesApi.Web
         }
 
         ///<inheritdoc/>
-        public Task<RepositoryItem<T>> CreateItemAsync(T item)
+        public async Task<RepositoryItem<T>> CreateItemAsync(T item)
         {
-            var task = retryPolicy.ExecuteAsync(() => repository.CreateItemAsync(item));
+            var repositoryItem = await retryPolicy.ExecuteAsync(() => repository.CreateItemAsync(item));
             ClearAllItemsPredicateCachedKeys();
-            return task;
+            return repositoryItem;
         }
 
         ///<inheritdoc/>
-        public Task DeleteItemAsync(string id)
+        public async Task DeleteItemAsync(string id)
         {
             if (cache.TryGetValue(id, out var cachedRepositoryItem))
             {
                 cache.Remove(id);
             }
 
-
-            var task = retryPolicy.ExecuteAsync(() => repository.DeleteItemAsync(id));
+            await retryPolicy.ExecuteAsync(() => repository.DeleteItemAsync(id));
             ClearAllItemsPredicateCachedKeys();
-            return task;
         }
 
         ///<inheritdoc/>
@@ -104,16 +102,16 @@ namespace TesApi.Web
         }
 
         ///<inheritdoc/>
-        public Task<RepositoryItem<T>> UpdateItemAsync(string id, RepositoryItem<T> item)
+        public async Task<RepositoryItem<T>> UpdateItemAsync(string id, RepositoryItem<T> item)
         {
             if (cache.TryGetValue(id, out var cachedRepositoryItem))
             {
                 cache.Remove(id);
             }
 
-            var task = retryPolicy.ExecuteAsync(() => repository.UpdateItemAsync(id, item));
+            var repositoryItem = await retryPolicy.ExecuteAsync(() => repository.UpdateItemAsync(id, item));
             ClearAllItemsPredicateCachedKeys();
-            return task;
+            return repositoryItem;
         }
 
         private void ClearAllItemsPredicateCachedKeys()

--- a/src/TesApi.Web/DeleteCompletedBatchJobsHostedService.cs
+++ b/src/TesApi.Web/DeleteCompletedBatchJobsHostedService.cs
@@ -102,9 +102,10 @@ namespace TesApi.Web
                 var tesTaskId = jobId.Split(new[] { '-' })[0];
                 logger.LogInformation($"TES task Id to delete: {tesTaskId}");
 
-                var repositoryItem = await repository.GetItemAsync(tesTaskId);
+                RepositoryItem<TesTask> repositoryItem = null;
+                var itemFound = await repository.TryGetItemAsync(tesTaskId, item => repositoryItem = item);
 
-                if (repositoryItem != null)
+                if (itemFound)
                 {
                     if (repositoryItem.Value.State == TesState.COMPLETEEnum ||
                         repositoryItem.Value.State == TesState.EXECUTORERROREnum ||

--- a/src/TesApi.Web/IRepository.cs
+++ b/src/TesApi.Web/IRepository.cs
@@ -31,8 +31,16 @@ namespace TesApi.Web
         /// Get an item by ID
         /// </summary>
         /// <param name="id">The ID of the item to retrieve</param>
+        /// <param name="onSuccess">The action to run when the item with the ID is found</param>
         /// <returns>The item instance</returns>
-        Task<RepositoryItem<T>> GetItemAsync(string id);
+        Task<bool> TryGetItemAsync(string id, Action<RepositoryItem<T>> onSuccess = null);
+
+        /// <summary>
+        /// Reads a collection of items from the repository
+        /// </summary>
+        /// <param name="predicate">The 'where' clause</param>
+        /// <returns>The collection of retrieved items</returns>
+        Task<IEnumerable<RepositoryItem<T>>> GetItemsAsync(Expression<Func<T, bool>> predicate);
 
         /// <summary>
         /// Reads a collection of items from the repository

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -75,7 +75,11 @@ namespace TesApi.Web
                 });
 
             (var cosmosDbEndpoint, var cosmosDbKey) = azureProxy.GetCosmosDbEndpointAndKeyAsync(Configuration["CosmosDbAccountName"]).Result;
-            services.AddSingleton<IRepository<TesTask>>(new CosmosDbRepository<TesTask>(cosmosDbEndpoint, cosmosDbKey, CosmosDbDatabaseId, CosmosDbCollectionId, CosmosDbPartitionId));
+
+            var cosmosDbRepository = new CosmosDbRepository<TesTask>(cosmosDbEndpoint, cosmosDbKey, CosmosDbDatabaseId, CosmosDbCollectionId, CosmosDbPartitionId);
+            var repository = new CachingWithRetriesRepository<TesTask>(cosmosDbRepository);
+
+            services.AddSingleton<IRepository<TesTask>>(repository);
             services.AddSingleton<IBatchScheduler>(new BatchScheduler(loggerFactory.CreateLogger<BatchScheduler>(), Configuration, cachingAzureProxy));
 
             services

--- a/src/TesApi.Web/TesApi.Web.csproj
+++ b/src/TesApi.Web/TesApi.Web.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.14.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.4.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.3" />


### PR DESCRIPTION
1. Add Polly for retries for CosmosDB repository access calls - 3 retries with exponential delays for waiting between each call (2 seconds raised to the power of attempt number)
2. Add memory caching for frequent CosmosDB calls to get one or all items
3. Refactor GetItemAsync to TryGetItemAsync - returns NotFound for task ids that do not exist

Addresses #85 and part of #76 (for CosmosDB calls only)