### PR TITLE
Correcting docker issues

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -396,6 +396,7 @@ namespace CromwellOnAzureDeployer
             await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "mount_containers.sh")), "/cromwellazure/mount_containers.sh", true);
             await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "cromwellazure.service")), "/lib/systemd/system/cromwellazure.service", false);
             await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "mount.blobfuse")), "/usr/sbin/mount.blobfuse", true);
+            await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "cromwell-application.conf")), "/cromwellazure/cromwell-application.conf", true);
 
             WriteExecutionTime(line, startTime);
         }

--- a/src/deploy-cromwell-on-azure/scripts/docker-compose.yml
+++ b/src/deploy-cromwell-on-azure/scripts/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - type: bind
         source: /cromwellazure/cromwell-tmp
         target: /cromwell-tmp
+      - /cromwellazure/cromwell-application.conf:/configuration/cromwell-application.conf:rw
     entrypoint:
       - /bin/sh
       - -c

--- a/src/deploy-cromwell-on-azure/scripts/install-cromwellazure.sh
+++ b/src/deploy-cromwell-on-azure/scripts/install-cromwellazure.sh
@@ -4,7 +4,7 @@
 
 # Install Docker and Docker Compose
 sudo apt update
-sudo apt install apt-transport-https ca-certificates curl software-properties-common
+sudo apt install -y apt-transport-https ca-certificates curl software-properties-common
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
 sudo apt update
@@ -13,6 +13,9 @@ sudo apt -y install docker-ce
 sudo curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 sudo docker-compose --version
+
+# Add vmadmin user to Docker group (Allows running of docker and docker-compose commands without sudoer permissions)
+sudo usermod -aG docker vmadmin
 
 # Install Blobfuse
 sudo wget https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb

--- a/src/deploy-cromwell-on-azure/scripts/mount_containers.sh
+++ b/src/deploy-cromwell-on-azure/scripts/mount_containers.sh
@@ -128,4 +128,4 @@ docker_compose_overrides="version: \"3.6\"\nservices:\n  cromwell:\n    volumes:
 echo -e "$docker_compose_overrides" > "docker-compose.override.yml"
 
 # Execute fstab
-sudo mount -av -t fuse
+echo "$(sudo mount -av -t fuse)"


### PR DESCRIPTION
#92 resolved with this pull request.

Added `vmadmin` to the `docker` group to allow access to the docker daemon since all docker-compose commands are run as `vmadmin` without `sudo` commands.

`fstab` commands were prematurely exiting the `startup.sh` script before `docker-compose` commands were able to be run. Capturing output of `fstab` command without exiting.