### PR TITLE
#92 - adding vmadmin to docker group to allow access to docker daemon…

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -404,7 +404,7 @@ namespace CromwellOnAzureDeployer
         {
             var startTime = DateTime.UtcNow;
             var line = RefreshableConsole.WriteLine("Running installation script on the VM...");
-            await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"/cromwellazure/install-cromwellazure.sh");
+            await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"/cromwellazure/install-cromwellazure.sh > /cromwellazure/install.log");
             await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo usermod -aG docker {configuration.VmUsername}");
             WriteExecutionTime(line, startTime);
         }

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -377,7 +377,7 @@ namespace CromwellOnAzureDeployer
 
         private async Task ConfigureVmAsync(ConnectionInfo sshConnectionInfo)
         {
-            await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, "sudo mkdir /cromwellazure && sudo chown vmadmin /cromwellazure && sudo chmod ug=rwx,o= /cromwellazure");
+            await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo mkdir /cromwellazure && sudo chown {configuration.VmUsername} /cromwellazure && sudo chmod ug=rwx,o= /cromwellazure");
             await CopyInstallationFilesAsync(sshConnectionInfo);
             await Task.WhenAll(new[] { RunInstallationScriptAsync(sshConnectionInfo), CopyAnyCustomDockerImagesToTheVmAsync(sshConnectionInfo) });
             await LoadAnyCustomDockerImagesAndCopyDockerComposeFileAsync(sshConnectionInfo);
@@ -405,6 +405,7 @@ namespace CromwellOnAzureDeployer
             var startTime = DateTime.UtcNow;
             var line = RefreshableConsole.WriteLine("Running installation script on the VM...");
             await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"/cromwellazure/install-cromwellazure.sh");
+            await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo usermod -aG docker {configuration.VmUsername}");
             WriteExecutionTime(line, startTime);
         }
 

--- a/src/deploy-cromwell-on-azure/scripts/install-cromwellazure.sh
+++ b/src/deploy-cromwell-on-azure/scripts/install-cromwellazure.sh
@@ -14,9 +14,6 @@ sudo curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-c
 sudo chmod +x /usr/local/bin/docker-compose
 sudo docker-compose --version
 
-# Add vmadmin user to Docker group (Allows running of docker and docker-compose commands without sudoer permissions)
-sudo usermod -aG docker vmadmin
-
 # Install Blobfuse
 sudo wget https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb

--- a/src/deploy-cromwell-on-azure/scripts/install-cromwellazure.sh
+++ b/src/deploy-cromwell-on-azure/scripts/install-cromwellazure.sh
@@ -4,7 +4,7 @@
 
 # Install Docker and Docker Compose
 sudo apt update
-sudo apt install apt-transport-https ca-certificates curl software-properties-common
+sudo apt install -y apt-transport-https ca-certificates curl software-properties-common
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
 sudo apt update
@@ -13,6 +13,9 @@ sudo apt -y install docker-ce
 sudo curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 sudo docker-compose --version
+
+# Add vmadmin user to Docker group (Allows running of docker and docker-compose commands without sudoer permissions)
+sudo usermod -aG docker vmadmin
 
 # Install Blobfuse
 sudo wget https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb


### PR DESCRIPTION
Associated with issue #92. 

`startup.sh` script couldn't run docker commands due to the commands not being run as a sudoer. Adding `vmadmin` user to the `docker` group corrects this issue.