### PR TITLE
Update FastqToUbamSingleSample.wdl

### DIFF
--- a/samples/quickstart/FastqToUbamSingleSample.wdl
+++ b/samples/quickstart/FastqToUbamSingleSample.wdl
@@ -61,9 +61,6 @@ task FastqToUbam {
 
     runtime {
         docker: docker_image
-        memory: "32 GB"
-        cpu: "16"
-        disk: disk_size + " GB"
     }
 
     output {


### PR DESCRIPTION
Runtime specs result in error: 
 "No VM (out of 210) available with the required resources (cores: 16, memory: 32 GB, disk: 784578 GB, preemptible: True)"