### PR TITLE
Allowing the user running the update to run sudo without having to...

### DIFF
--- a/src/deploy-cromwell-on-azure/scripts/cromwellazure.service
+++ b/src/deploy-cromwell-on-azure/scripts/cromwellazure.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CromwellOnAzure
-RequiresMountsFor=/data
+RequiresMountsFor=/data /mnt
 
 [Service]
 ExecStart=/bin/bash /data/cromwellazure/startup.sh

--- a/src/deploy-cromwell-on-azure/scripts/mount.blobfuse
+++ b/src/deploy-cromwell-on-azure/scripts/mount.blobfuse
@@ -2,6 +2,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+set -o errexit
+set -o nounset
+set -o errtrace
+
+trap 'write_log "Error mounting $1. Exit code: $?"' ERR
+
 readonly log_file="/data/cromwellazure/mount.blobfuse.log"
 touch $log_file
 exec 1>>$log_file
@@ -14,23 +20,22 @@ function write_log() {
 
 account_name=$(echo $3 | grep -Po '(?i)account_name=\K([^,]*)')
 container_name=$(echo $3 | grep -Po '(?i)container_name=\K([^,]*)')
-account_key=$(echo $3 | grep -Po '(?i)account_key=\K([^,]*)')
-sas_token=$(echo $3 | grep -Po '(?i)sas_token=\K([^,]*)')
+account_key=$(echo $3 | grep -Po '(?i)account_key=\K([^,]*)' || :)
+sas_token=$(echo $3 | grep -Po '(?i)sas_token=\K([^,]*)' || :)
 
 ps -C blobfuse --format "cmd" | [[ $(grep -c " $1 ") -eq 1 ]] && mountpoint -q $1 && exit 0
 [[ $(grep -c " $1 " /etc/mtab) -eq 1 ]] && { umount -f $1 || write_log "umount error code: $?"; }
 
-tmp_dir="/blobfusetmp/$account_name/$container_name"
+tmp_dir="/mnt/blobfusetmp/$account_name/$container_name"
+rm -rf $tmp_dir
 mkdir -p $tmp_dir
 
-if [[ $account_key != "" ]]
-then
+if [[ $account_key != "" ]]; then
     export AZURE_STORAGE_ACCOUNT=$account_name
     export AZURE_STORAGE_ACCESS_KEY=$account_key
     unset AZURE_STORAGE_SAS_TOKEN
     write_log "Mounting $1 using the account key"
-elif [[ $sas_token != "" ]]
-then
+elif [[ $sas_token != "" ]]; then
     export AZURE_STORAGE_ACCOUNT=$account_name
     unset AZURE_STORAGE_ACCESS_KEY
     export AZURE_STORAGE_SAS_TOKEN=$sas_token
@@ -39,9 +44,16 @@ else
     write_log "Error mounting $1. Either the account key or the SAS token must be specified." && exit 1
 fi
 
-/usr/bin/blobfuse $1 --tmp-path=$tmp_dir -o nonempty -o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other --container-name=$container_name --log-level=LOG_CRIT
-exitcode=$?
-[ $exitcode -eq 0 ] && write_log "Successfully mounted $1" || write_log "Error mounting $1. Exit code: $exitcode" && exit $exitcode
+error_message=$(/usr/bin/blobfuse $1 --tmp-path=$tmp_dir -o nonempty -o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other --container-name=$container_name --log-level=LOG_CRIT 2>&1 > /dev/null) && fuse_exit_code=0 || fuse_exit_code=$?
 
+if [[ $fuse_exit_code != 0 ]]; then
+    if [[ $account_key != "" ]]; then
+        write_log "Error mounting $1 using the account key. Exit code: $fuse_exit_code. Message: $error_message"
+        exit $fuse_exit_code
+    else
+        write_log "WARNING: Could not mount $1 using the SAS token. Workflows may fail if they access this container. Blobfuse exit code: $fuse_exit_code. Message: $error_message"
+        exit 0
+    fi
+fi
 
-
+write_log "Successfully mounted $1"

--- a/src/deploy-cromwell-on-azure/scripts/mount_containers.sh
+++ b/src/deploy-cromwell-on-azure/scripts/mount_containers.sh
@@ -139,7 +139,9 @@ done
 docker_compose_overrides="version: \"3.6\"\nservices:\n  cromwell:\n    volumes:\n$cromwell_volumes  tes:\n    environment:\n      - ExternalStorageContainers=$tes_ext_storage_containers\n"
 echo -e "$docker_compose_overrides" > "docker-compose.override.yml"
 
-# Execute fstab
+# Unmount existing mounts and remount using the updated /etc/fstab
+sudo umount -a -f -t fuse
+sudo rm -f /data/cromwellazure/mount.blobfuse.log
 sudo mount -av -t fuse
 
 echo "mount_containers completed successfully"


### PR DESCRIPTION
...supply password for each execution by adding "NOPASSWD:ALL" setting. This setting is present after creating the VM, but updating or adding the user in Azure portal removes it. 
Letting the system start (with a warning in mount_blobfuse.log) even if some blobfuse containers that use user-provided SAS token fail to mount. The startup will still fail for all other mount failures.
Informing the user that there is a warning in mount_blobfuse.log in deployer's console.