### PR TITLE
Remove container throughput

### DIFF
--- a/src/TesApi.Tests/TaskServiceApiControllerTests.cs
+++ b/src/TesApi.Tests/TaskServiceApiControllerTests.cs
@@ -61,18 +61,25 @@ namespace TesApi.Tests
         }
 
         [TestMethod]
-        public async Task CreateTaskAsync_CromwellJobIdIsUsedAsTaskIdPrefix()
+        public async Task CreateTaskAsync_CromwellWorkflowIdIsUsedAsTaskIdPrefix()
         {
-            var cromwellJobId = Guid.NewGuid().ToString();
-            var taskDescription = $"{cromwellJobId}:BackendJobDescriptorKey_CommandCallNode_wf_hello.hello:-1:1";
-            var tesTask = new TesTask() { Description = taskDescription, Executors = new List<TesExecutor> { new TesExecutor { Image = "ubuntu" } } };
+            var cromwellWorkflowId = Guid.NewGuid().ToString();
+            var cromwellSubWorkflowId = Guid.NewGuid().ToString();
+            var taskDescription = $"{cromwellSubWorkflowId}:BackendJobDescriptorKey_CommandCallNode_wf_hello.hello:-1:1";
+
+            var tesTask = new TesTask()
+            {
+                Description = taskDescription,
+                Executors = new List<TesExecutor> { new TesExecutor { Image = "ubuntu" } },
+                Inputs = new List<TesInput> { new TesInput { Path = $"/cromwell-executions/test/{cromwellWorkflowId}/call-hello/test-subworkflow/{cromwellSubWorkflowId}/call-subworkflow/shard-8/execution/script" } }
+            };
 
             var controller = this.GetTaskServiceApiController();
 
             await controller.CreateTaskAsync(tesTask);
 
             Assert.AreEqual(41, tesTask.Id.Length); // First eight characters of Cromwell's job id + underscore + GUID without dashes
-            Assert.IsTrue(tesTask.Id.StartsWith(cromwellJobId.Substring(0, 8) + "_"));
+            Assert.IsTrue(tesTask.Id.StartsWith(cromwellWorkflowId.Substring(0, 8) + "_"));
         }
 
         [TestMethod]

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -119,10 +119,6 @@ namespace TesApi.Controllers
                 return BadRequest("Docker container image name is required.");
             }
 
-            // If the description starts with a GUID (Cromwell's job id), prefix the TES task id with first eight characters (of job id) to facilitate easier debugging
-            var tesTaskIdPrefix = tesTask.Description?.Length >= 36 && Guid.TryParse(tesTask.Description.Substring(0, 36), out _) ? $"{tesTask.Description.Substring(0, 8)}_" : "";
-
-            tesTask.Id = $"{tesTaskIdPrefix}{Guid.NewGuid().ToString("N")}";
             tesTask.State = TesState.QUEUEDEnum;
             tesTask.CreationTime = DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz", DateTimeFormatInfo.InvariantInfo);
 
@@ -134,6 +130,10 @@ namespace TesApi.Controllers
                 ?.Split('/', StringSplitOptions.RemoveEmptyEntries)
                 ?.Skip(2)
                 ?.FirstOrDefault();
+
+            // Prefix the TES task id with first eight characters of root Cromwell job id to facilitate easier debugging
+            var tesTaskIdPrefix = tesTask.WorkflowId != null && Guid.TryParse(tesTask.WorkflowId, out _) ? $"{tesTask.WorkflowId.Substring(0, 8)}_" : "";
+            tesTask.Id = $"{tesTaskIdPrefix}{Guid.NewGuid().ToString("N")}";
 
             // For CWL workflows, if disk size is not specified in TES object (always), try to retrieve it from the corresponding workflow stored by Cromwell in /cromwell-tmp directory
             // Also allow for TES-style "memory" and "cpu" hints in CWL.

--- a/src/TesApi.Web/CosmosDbRepository.cs
+++ b/src/TesApi.Web/CosmosDbRepository.cs
@@ -205,7 +205,7 @@ namespace TesApi.Web
                 {
                     var documentCollection = new DocumentCollection { Id = collectionId };
                     documentCollection.PartitionKey.Paths.Add($"/{PartitionKeyFieldName}");
-                    await client.CreateDocumentCollectionAsync(databaseUri, documentCollection, new RequestOptions { OfferThroughput = 400 });
+                    await client.CreateDocumentCollectionAsync(databaseUri, documentCollection);
                 }
                 else
                 {

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -992,7 +992,8 @@ namespace CromwellOnAzureDeployer
 
         private Task<IIdentity> CreateUserManagedIdentityAsync(IResourceGroup resourceGroup)
         {
-            var managedIdentityName = $"{resourceGroup.Name}-identity";
+            // Resource group name supports periods and parenthesis but identity doesn't. Replacing them with hyphens.
+            var managedIdentityName = $"{resourceGroup.Name.Replace(".", "-").Replace("(", "-").Replace(")", "-")}-identity";
 
             return Execute(
                 $"Creating user-managed identity: {managedIdentityName}...",

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -394,7 +394,7 @@ namespace CromwellOnAzureDeployer
             catch (Microsoft.Rest.Azure.CloudException cloudException)
             {
                 RefreshableConsole.WriteLine();
-                RefreshableConsole.WriteLine(cloudException.Message, ConsoleColor.Red);
+                RefreshableConsole.WriteLine($"{cloudException.GetType().Name}: {cloudException.Message}", ConsoleColor.Red);
                 RefreshableConsole.WriteLine();
                 WriteGeneralRetryMessageToConsole();
                 Debugger.Break();
@@ -404,7 +404,7 @@ namespace CromwellOnAzureDeployer
             catch (Exception exc)
             {
                 RefreshableConsole.WriteLine();
-                RefreshableConsole.WriteLine(exc.Message, ConsoleColor.Red);
+                RefreshableConsole.WriteLine($"{exc.GetType().Name}: {exc.Message}", ConsoleColor.Red);
                 RefreshableConsole.WriteLine();
                 Debugger.Break();
                 WriteGeneralRetryMessageToConsole();
@@ -1415,9 +1415,9 @@ namespace CromwellOnAzureDeployer
                     line.Write(" Cancelled", ConsoleColor.Red);
                     return await Task.FromCanceled<T>(cts.Token);
                 }
-                catch
+                catch (Exception ex)
                 {
-                    line.Write($" Failed", ConsoleColor.Red);
+                    line.Write($" Failed. Exception: {ex.GetType().Name}", ConsoleColor.Red);
                     cts.Cancel();
                     throw;
                 }


### PR DESCRIPTION
1. Not setting dedicated cosmos container throughput for new installations. The container will use the one set at the database level.
2. Prefixing TES Task id with first 8 characters of root workflow id instead of subworkflow id, to make it easier to identify all tasks that belong to a Cromwell workflow. 
3. Verifying access to containers-to-mount file before proceeding with startup.
4. User-managed identity name is derived from resource group name. Replacing invalid characters (period and parenthesis) with hyphens.