### PR TITLE
Add mysql-init files to unlock change log

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -665,6 +665,8 @@ namespace CromwellOnAzureDeployer
                     await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "docker-compose.yml")), $"{CromwellAzureRootDir}/docker-compose.yml", false);
                     await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "cromwellazure.service")), "/lib/systemd/system/cromwellazure.service", false);
                     await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "mount.blobfuse")), "/usr/sbin/mount.blobfuse", true);
+                    await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "mysql-init", "init-user.sql")), $"{CromwellAzureRootDir}/mysql-init/init-user.sql", false);
+                    await UploadFileToVirtualMachineAsync(sshConnectionInfo, ReadAllTextWithUnixLineEndings(GetPathFromAppRelativePath("scripts", "mysql-init", "unlock-change-log.sql")), $"{CromwellAzureRootDir}/mysql-init/unlock-change-log.sql", false);
                 });
         }
 

--- a/src/deploy-cromwell-on-azure/deploy-cromwell-on-azure.csproj
+++ b/src/deploy-cromwell-on-azure/deploy-cromwell-on-azure.csproj
@@ -91,6 +91,12 @@
     <None Update="scripts\wait-for-it.sh">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="scripts\mysql-init\init-user.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="scripts\mysql-init\unlock-change-log.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="test.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/deploy-cromwell-on-azure/scripts/docker-compose.yml
+++ b/src/deploy-cromwell-on-azure/scripts/docker-compose.yml
@@ -38,10 +38,14 @@ services:
       - type: bind
         source: /data/mysql
         target: /var/lib/mysql
+      - type: bind
+        source: /data/cromwellazure/mysql-init
+        target: /mysql-init
     entrypoint:
       - /bin/sh
       - -c
-    command: ["echo \"CREATE USER 'cromwell'@'localhost' IDENTIFIED BY 'cromwell'; GRANT ALL PRIVILEGES ON cromwell_db.* TO 'cromwell'@'localhost' WITH GRANT OPTION; CREATE USER 'cromwell'@'%' IDENTIFIED BY 'cromwell'; GRANT ALL PRIVILEGES ON cromwell_db.* TO 'cromwell'@'%' WITH GRANT OPTION;\" > /docker-entrypoint-initdb.d/init_user.sql && docker-entrypoint.sh mysqld && echo \"Deleting change log lock table...\" && mysql -u cromwell -p cromwell -e \"DELETE FROM DATABASECHANGELOGLOCK;\""]
+    command: ["ln -sf /mysql-init/init-user.sql /docker-entrypoint-initdb.d/init_user.sql \
+      && docker-entrypoint.sh mysqld --init-file /mysql-init/unlock-change-log.sql"]
     expose:
       - "3306"
     restart: unless-stopped

--- a/src/deploy-cromwell-on-azure/scripts/mysql-init/init-user.sql
+++ b/src/deploy-cromwell-on-azure/scripts/mysql-init/init-user.sql
@@ -1,0 +1,5 @@
+CREATE USER 'cromwell'@'localhost' IDENTIFIED BY 'cromwell';
+GRANT ALL PRIVILEGES ON cromwell_db.* TO 'cromwell'@'localhost' WITH GRANT OPTION;
+CREATE USER 'cromwell'@'%' IDENTIFIED BY 'cromwell'; 
+GRANT ALL PRIVILEGES ON cromwell_db.* TO 'cromwell'@'%' WITH GRANT OPTION;
+FLUSH PRIVILEGES;

--- a/src/deploy-cromwell-on-azure/scripts/mysql-init/unlock-change-log.sql
+++ b/src/deploy-cromwell-on-azure/scripts/mysql-init/unlock-change-log.sql
@@ -1,0 +1,11 @@
+USE mysql;
+DROP PROCEDURE IF EXISTS remove_change_lock;
+DELIMITER $$
+CREATE PROCEDURE remove_change_lock()
+    BEGIN IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'cromwell_db' AND table_name = 'DATABASECHANGELOGLOCK')
+        THEN UPDATE cromwell_db.DATABASECHANGELOGLOCK SET LOCKED = 0, LOCKGRANTED = null, LOCKEDBY = null WHERE ID = 1;
+        END IF;
+    END$$
+DELIMITER ;
+CALL remove_change_lock();
+DROP PROCEDURE IF EXISTS remove_change_lock;


### PR DESCRIPTION
Addresses #57 
Simplify docker compose command for mysql
Add two files to scripts: one to create the cromwell user, another to unlock the change log in case of container restarts

Tested by restarting the containers on a CoA instance to ensure the unlocking SQL runs
