### PR TITLE
Bemosk/issue125 existing virtual network

### DIFF
--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -36,8 +36,9 @@ namespace CromwellOnAzureDeployer
         public string CustomTriggerServiceImagePath { get; set; }
         public bool SkipTestWorkflow { get; set; } = false;
         public bool Update { get; set; } = false;
-        public string ExistingVNet { get; set; }
-        public string ExistingVNetResourceGroup { get; set; }
+        public string VnetResourceGroupName { get; set; }
+        public string VnetName { get; set; }
+        public string SubnetName { get; set; }
 
         public static Configuration BuildConfiguration(string[] args)
         {

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -38,7 +38,6 @@ namespace CromwellOnAzureDeployer
         public bool Update { get; set; } = false;
         public string ExistingVNet { get; set; }
         public string ExistingVNetResourceGroup { get; set; }
-        public string ExistingVNetSubscriptionId { get; set; }
 
         public static Configuration BuildConfiguration(string[] args)
         {

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -38,6 +38,7 @@ namespace CromwellOnAzureDeployer
         public bool Update { get; set; } = false;
         public string ExistingVNet { get; set; }
         public string ExistingVNetResourceGroup { get; set; }
+        public string ExistingVNetSubscriptionId { get; set; }
 
         public static Configuration BuildConfiguration(string[] args)
         {

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -12,7 +12,7 @@ namespace CromwellOnAzureDeployer
     public class Configuration
     {
         public string SubscriptionId { get; set; }
-        public string RegionName { get; set; } = "westus";
+        public string RegionName { get; set; } = "westus2";
         public string MainIdentifierPrefix { get; set; } = "coa";
         public string VmOsVersion { get; set; } = "18.04-LTS";
         public string VmSize { get; set; } = "Standard_D3_v2";
@@ -36,6 +36,8 @@ namespace CromwellOnAzureDeployer
         public string CustomTriggerServiceImagePath { get; set; }
         public bool SkipTestWorkflow { get; set; } = false;
         public bool Update { get; set; } = false;
+        public string ExistingVNet { get; set; }
+        public string ExistingVNetResourceGroup { get; set; }
 
         public static Configuration BuildConfiguration(string[] args)
         {

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1161,8 +1161,8 @@ namespace CromwellOnAzureDeployer
 
         private IAzure GetExistVNetAzureClient()
         {
-            IAzure existingVNetAzureClient = null;
-            if (configuration.SubscriptionId == configuration.ExistingVNetSubscriptionId)
+            IAzure existingVNetAzureClient;
+            if (String.IsNullOrEmpty(configuration.ExistingVNetSubscriptionId) || configuration.SubscriptionId == configuration.ExistingVNetSubscriptionId)
             {
                 existingVNetAzureClient = azureClient;
             }
@@ -1174,7 +1174,12 @@ namespace CromwellOnAzureDeployer
                 }
                 catch (Exception)
                 {
-                    throw new ValidationException($"unable to create an azure client for subscription ID {configuration.ExistingVNetSubscriptionId}");
+                    var errorMessage = $"unable to create an azure client for subscription ID {configuration.ExistingVNetSubscriptionId}";
+                    if (String.IsNullOrEmpty(configuration.ExistingVNetSubscriptionId))
+                    {
+                        errorMessage += "\nplease submit a value for \"--ExistingVNetSubscriptionId\"";
+                    }
+                    throw new ValidationException(errorMessage);
                 }
             }
 

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -537,16 +537,11 @@ namespace CromwellOnAzureDeployer
 
         private IAzure GetAzureClient(AzureCredentials azureCredentials)
         {
-            return GetAzureClient(azureCredentials, configuration.SubscriptionId);
-        }
-
-        private IAzure GetAzureClient(AzureCredentials azureCredentials, string subscriptionId)
-        {
             return Azure
                 .Configure()
                 .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                 .Authenticate(azureCredentials)
-                .WithSubscription(subscriptionId);
+                .WithSubscription(configuration.SubscriptionId);
         }
 
         private IResourceManager GetResourceManagerClient(AzureCredentials azureCredentials)
@@ -923,8 +918,7 @@ namespace CromwellOnAzureDeployer
                     .WithNewDataDisk(dataDiskSizeGiB, dataDiskLun, CachingTypes.None)
                     .WithSize(configuration.VmSize)
                     .WithExistingUserAssignedManagedServiceIdentity(managedIdentity)
-                    .CreateAsync(cts.Token)
-                );
+                    .CreateAsync(cts.Token));
         }
 
         private IWithNetwork GetWithNetwork()
@@ -1157,12 +1151,9 @@ namespace CromwellOnAzureDeployer
             {
                 throw new ValidationException($"cannot locate any subnets on the existing primary network for vnet {configuration.ExistingVNet} in resource group {configuration.ExistingVNetResourceGroup}");
             }
-            if (subnets.Count() != 1)
-            {
-                throw new ValidationException($"more than one subnets on the existing primary network for vnet {configuration.ExistingVNet} in resource group {configuration.ExistingVNetResourceGroup}");
-            }
             existingPrimaryNetworkSubnet = subnets.First().Key;
         }
+
 
         private static string ReadAllTextWithUnixLineEndings(string path)
         {


### PR DESCRIPTION
PR for resolving issue https://github.com/microsoft/CromwellOnAzure/issues/125

The CoA Deployer accepts parameters ExistingVNet and ExistingVNetResourceGroup.  If these are present and specify an existing VNet, new CoA cluster is created and links to the existing VNet rather than creating a new VNet, which was the prior behavior.

The new feature was tested by doing the following

1) creating a new CoA cluster from scratch (assuring previous functionality wasn't broken)
2) create a new CoA cluster linking to the VNet created in step 1
3) validate that the VNet from Step 1 now contains the Network Interfaces from both Steps 1 & 2