### PR TITLE
Workaround for blobxfer issue when downloading nested blobs using container SAS

### DIFF
--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -492,9 +492,10 @@ namespace TesApi.Web
             var additionalInputFiles = blobsInExecutionDirectory.Select(b => $"{CromwellPathPrefix}{b}").Select(b => new TesInput { Content = null, Path = b, Url = b, Name = Path.GetFileName(b), Type = TesFileType.FILEEnum });
             var filesToDownload = await Task.WhenAll(inputFiles.Union(additionalInputFiles).Select(async f => await GetTesInputFileUrl(f, task.Id, queryStringsToRemoveFromLocalFilePaths)));
 
+            // Using --include and not using --no-recursive as a workaround for https://github.com/Azure/blobxfer/issues/123
             var downloadFilesScriptContent = string.Join(" && ", filesToDownload.Select(f => 
                 f.Url.Contains(".blob.core.") 
-                    ? $"blobxfer download --storage-url '{f.Url}' --local-path '{f.Path}' --chunk-size-bytes 104857600 --rename --no-recursive"
+                    ? $"blobxfer download --storage-url '{f.Url}' --local-path '{f.Path}' --chunk-size-bytes 104857600 --rename --include '{StorageAccountUrlSegments.Create(f.Url).BlobName}'"
                     : $"mkdir -p {GetParentPath(f.Path)} && wget -O '{f.Path}' '{f.Url}'"));
 
             var downloadFilesScriptPath = $"{batchExecutionDirectoryPath}/{DownloadFilesScriptFileName}";

--- a/src/TesApi.Web/StorageAccountUrlSegments.cs
+++ b/src/TesApi.Web/StorageAccountUrlSegments.cs
@@ -83,6 +83,19 @@ namespace TesApi.Web
         }
 
         /// <summary>
+        /// Parses the provided string. The following formats are supported:
+        /// - /accountName/containerName/blobName
+        /// - https://accountName.blob.core.windows.net/containerName/blobName?sasToken
+        /// Throws if string cannot be parsed.
+        /// </summary>
+        /// <param name="uriString">String representing an Azure Storage object location</param>
+        /// <returns><see cref="StorageAccountUrlSegments"/> representing the provided object location</returns>
+        public static StorageAccountUrlSegments Create(string uriString)
+        {
+            return TryCreate(uriString, out var result) ? result : throw new ArgumentException($"Invalid blob URI: {uriString}");
+        }
+
+        /// <summary>
         /// Returns the Blob URL string
         /// </summary>
         /// <returns>Blob URL</returns>


### PR DESCRIPTION
Blobxfer issue: https://github.com/Azure/blobxfer/issues/123
#134

Workaround is to do the recursive download (so remove the --no-recursive flag), but specify the exact blob name in the --include parameter. 