### PR TITLE
Autoscale throughput fix

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -173,8 +173,6 @@ namespace CromwellOnAzureDeployer
                         await AssociateNicWithNetworkSecurityGroupAsync(linuxVm.GetPrimaryNetworkInterface(), networkSecurityGroup);
                     }
 
-                    var installedVersion = await GetInstalledCromwellOnAzureVersionAsync(sshConnectionInfo);
-
                     await ConfigureVmAsync(sshConnectionInfo);
 
                     var accountNames = DelimitedTextToDictionary((await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"cat {CromwellAzureRootDir}/env-01-account-names.txt || echo ''")).Output);
@@ -219,9 +217,11 @@ namespace CromwellOnAzureDeployer
 
                     await WriteNonPersonalizedFilesToStorageAccountAsync(storageAccount);
 
-                    if(installedVersion == null)
+                    var installedVersion = await GetInstalledCromwellOnAzureVersionAsync(sshConnectionInfo);
+
+                    if (installedVersion == null)
                     {
-                        // If upgrading from pre-2.0 version, patch the installed cromwell-application.conf (disable call caching and default to preemptible)
+                        // If upgrading from pre-2.1 version, patch the installed cromwell-application.conf (disable call caching and default to preemptible)
                         await PatchCromwellConfigurationFileAsync(storageAccount);
                         await SetCosmosDbContainerAutoScaleAsync(cosmosDb);
                     }
@@ -330,6 +330,7 @@ namespace CromwellOnAzureDeployer
                     await AssignVmAsDataReaderToStorageAccountAsync(managedIdentity, storageAccount);
                 }
 
+                await WriteCoaVersionToVmAsync(sshConnectionInfo);
                 await RestartVmAsync(linuxVm);
                 await WaitForSshConnectivityAsync(sshConnectionInfo);
 
@@ -629,7 +630,7 @@ namespace CromwellOnAzureDeployer
 
         private async Task<Version> GetInstalledCromwellOnAzureVersionAsync(ConnectionInfo sshConnectionInfo)
         {
-            var versionString = (await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $@"grep -sPo 'CromwellOnAzureVersion=\K(.*)$' {CromwellAzureRootDir}/env-02-internal-images.txt || :")).Output;
+            var versionString = (await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $@"grep -sPo 'CromwellOnAzureVersion=\K(.*)$' {CromwellAzureRootDir}/env-00-coa-version.txt || :")).Output;
 
             return !string.IsNullOrEmpty(versionString) && Version.TryParse(versionString, out var version) ? version : null;
         }
@@ -664,6 +665,13 @@ namespace CromwellOnAzureDeployer
                         (GetFileContent("scripts", "mysql-init", "init-user.sql"), $"{CromwellAzureRootDir}/mysql-init/init-user.sql", false),
                         (GetFileContent("scripts", "mysql-init", "unlock-change-log.sql"), $"{CromwellAzureRootDir}/mysql-init/unlock-change-log.sql", false)
                     }));
+        }
+
+        private Task WriteCoaVersionToVmAsync(ConnectionInfo sshConnectionInfo)
+        {
+            return Execute(
+                $"Writing CoA version file to the VM...",
+                () => UploadFilesToVirtualMachineAsync(sshConnectionInfo, (GetFileContent("scripts", "env-00-coa-version.txt"), $"{CromwellAzureRootDir}/env-00-coa-version.txt", false)));
         }
 
         private Task RunInstallationScriptAsync(ConnectionInfo sshConnectionInfo)
@@ -1078,11 +1086,9 @@ namespace CromwellOnAzureDeployer
             if (requestThroughput != null && requestThroughput.Throughput != null && requestThroughput.AutoscaleMaxThroughput == null)
             {
                 // If the container has request throughput setting configured, and it is currently manual, set it to auto
-                var effectiveMaxAutoScaleThroughput = Math.Max(requestThroughput.Throughput.Value, MaxAutoScaleThroughput);
-
                 await Execute(
-                    $"Replacing the throughput settings for CosmosDb container 'Tasks' in database 'TES' with autoscale throughput with max of {effectiveMaxAutoScaleThroughput} units...",
-                    () => cosmosClient.SetContainerAutoRequestThroughputAsync("TES", "Tasks", effectiveMaxAutoScaleThroughput));
+                    $"Switching the throughput setting for CosmosDb container 'Tasks' in database 'TES' from Manual to Autoscale...",
+                    () => cosmosClient.SwitchContainerRequestThroughputToAutoAsync("TES", "Tasks"));
             }
         }
 

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -294,9 +294,9 @@ namespace CromwellOnAzureDeployer
                         Task.Run(async () => cosmosDb = await CreateCosmosDbAsync()),
 
                         Task.Run(() => CreateStorageAccountAsync()
-                            .ContinueWith(async t => 
-                                { 
-                                    storageAccount = t.Result; 
+                            .ContinueWith(async t =>
+                                {
+                                    storageAccount = t.Result;
                                     await WriteNonPersonalizedFilesToStorageAccountAsync(storageAccount);
                                     await WritePersonalizedFilesToStorageAccountAsync(storageAccount);
                                 },
@@ -392,20 +392,14 @@ namespace CromwellOnAzureDeployer
                 DisplayValidationExceptionAndExit(validationException);
                 return 1;
             }
-            catch (Microsoft.Rest.Azure.CloudException cloudException)
-            {
-                RefreshableConsole.WriteLine();
-                RefreshableConsole.WriteLine($"{cloudException.GetType().Name}: {cloudException.Message}", ConsoleColor.Red);
-                RefreshableConsole.WriteLine();
-                WriteGeneralRetryMessageToConsole();
-                Debugger.Break();
-                await DeleteResourceGroupIfUserConsentsAsync();
-                return 1;
-            }
             catch (Exception exc)
             {
-                RefreshableConsole.WriteLine();
-                RefreshableConsole.WriteLine($"{exc.GetType().Name}: {exc.Message}", ConsoleColor.Red);
+                if (!(exc is OperationCanceledException && cts.Token.IsCancellationRequested))
+                {
+                    RefreshableConsole.WriteLine();
+                    RefreshableConsole.WriteLine($"{exc.GetType().Name}: {exc.Message}", ConsoleColor.Red);
+                }
+
                 RefreshableConsole.WriteLine();
                 Debugger.Break();
                 WriteGeneralRetryMessageToConsole();
@@ -1414,7 +1408,7 @@ namespace CromwellOnAzureDeployer
                 }
                 catch (Exception ex)
                 {
-                    line.Write($" Failed. Exception: {ex.GetType().Name}", ConsoleColor.Red);
+                    line.Write($" Failed. {ex.GetType().Name}: {ex.Message}", ConsoleColor.Red);
                     cts.Cancel();
                     throw;
                 }

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -51,7 +51,6 @@ namespace CromwellOnAzureDeployer
         private const string ConfigurationContainerName = "configuration";
         private const string InputsContainerName = "inputs";
         private const string CromwellAzureRootDir = "/data/cromwellazure";
-        private const int MaxAutoScaleThroughput = 4000;
 
         private readonly CancellationTokenSource cts = new CancellationTokenSource();
 

--- a/src/deploy-cromwell-on-azure/deploy-cromwell-on-azure.csproj
+++ b/src/deploy-cromwell-on-azure/deploy-cromwell-on-azure.csproj
@@ -64,6 +64,9 @@
     <None Update="scripts\env-01-account-names.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="scripts\env-00-coa-version.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="scripts\env-02-internal-images.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/deploy-cromwell-on-azure/scripts/env-00-coa-version.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-00-coa-version.txt
@@ -1,0 +1,1 @@
+﻿CromwellOnAzureVersion=2.0.0

--- a/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
@@ -1,3 +1,2 @@
 ﻿TesImageName=mcr.microsoft.com/cromwellonazure/tes:2.0.0
 TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:2.0.0
-CromwellOnAzureVersion=2.0.0


### PR DESCRIPTION
- Addressing the breaking change in CosmosDB offer REST API - since we released CoA 2.0, they starting requiring `x-ms-cosmos-migrate-offer-to-autopilot` header when switching from manual to auto throughput scaling. After that API change, 2.0 deployer silently fails to switch the throughput to auto.
- Writing the CoA version last into the new file, `env-00-coa-version.txt`, after all upgrade steps are completed, so the system doesn't end in a state where update is incomplete but the new version is written. 
- The new CoA version file will thus not be present in 2.0, so both the Cromwell config patch as well as the new throughput switch steps will run when upgrading from 1.* to 2.1 and 2.0 to 2.1.
- Already modified the build pipeline to insert the correct version to the new version file during build.

#135 