### PR TITLE
Documentation updates for version 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Welcome to Cromwell on Azure
+### Latest release
+ * [Release 2.0](https://github.com/microsoft/CromwellOnAzure/releases/tag/2.0.0)<br/>
+
+ Check the [release notes](docs/release-notes/2.0.0.md) to learn how to update an existing Cromwell on Azure deployment to version 2.0 and above. You can customize some parameters when updating. Please [see these customization instructions](docs/troubleshooting-guide.md/#Customize-your-Cromwell-on-Azure-deployment), specifically the "Used by update" and "Comment" columns in the table.<br/>
 
 #### Getting started
  * What is [Cromwell on Azure?](#Cromwell-on-Azure) <br/>
@@ -10,6 +14,7 @@
  * Here is an example workflow to [convert FASTQ files to uBAM files](docs/example-fastq-to-ubam.md/#Example-workflow-to-convert-FASTQ-files-to-uBAM-files)<br/>
  * Have an existing WDL file that you want to run on Azure? [Modify your existing WDL with these adaptations for Azure](docs/change-existing-WDL-for-Azure.md/#How-to-modify-an-existing-WDL-file-to-run-on-Cromwell-on-Azure)<br/>
  * Want to run commonly used workflows? [Find links to ready-to-use workflows here](#Run-Common-Workflows)<br/>
+ * Are there any examples of tertiary analysis or other genomics analysis? [Find links to related project here](#Related-Projects)<br/>
 
 #### Questions?
  * See our [Troubleshooting Guide](docs/troubleshooting-guide.md/#FAQs,-advanced-troubleshooting-and-known-issues-for-Cromwell-on-Azure) for more information.<br/>
@@ -33,8 +38,7 @@ Cromwell on Azure configures all Azure resources needed to run workflows through
 2. You must have the proper [Azure role assignments](https://docs.microsoft.com/en-us/azure/role-based-access-control/overview) to deploy Cromwell on Azure.  To check your current role assignments, please follow [these instructions](https://docs.microsoft.com/en-us/azure/role-based-access-control/check-access).  You must have one of the following combinations of [role assignments](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles):
    1. `Owner` of the subscription<br/>
    2. `Contributor` and `User Access Administrator` of the subscription
-   3. `Owner` of the resource group.
-      . *Note: this level of access will result in a warning during deployment, and will not use the latest VM pricing data.</i>  [Learn more](/docs/troubleshooting-guide.md/#How-are-Batch-VMs-selected-to-run-tasks-in-a-workflow?).  Also, you must specify the resource group name during deployment with this level of access (see below).*
+   3. `Owner` of the resource group. *Note: this level of access will result in a warning during deployment, and will not use the latest VM pricing data.</i>  [Learn more](/docs/troubleshooting-guide.md/#How-are-Batch-VMs-selected-to-run-tasks-in-a-workflow?).  Also, you must specify the resource group name during deployment with this level of access (see below).*
    4.  Note: if you only have `Service Administrator` as a role assignment, please assign yourself as `Owner` of the subscription.
 3. Install the [Azure Command Line Interface (az cli)](https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest), a command line experience for managing Azure resources.
 4. Run `az login` to authenticate with Azure.
@@ -44,7 +48,42 @@ Cromwell on Azure configures all Azure resources needed to run workflows through
 
 Download the required executable from [Releases](https://github.com/microsoft/CromwellOnAzure/releases). Choose the runtime of your choice from `win-x64`, `linux-x64`, `osx-x64`. *On Windows machines, we recommend using the `win-x64` runtime (deployment using the `linux-x64` runtime via the Windows Subsystem for Linux is not supported).*<br/>
 
-   *Optional: build the executable yourself.  Clone the [Cromwell on Azure repository](https://github.com/microsoft/CromwellOnAzure) and build the solution in Visual Studio 2019. Note that [VS 2019](https://visualstudio.microsoft.com/vs/) and [.NET Core SDK 3.0 and 2.2.x](https://dotnet.microsoft.com/download/dotnet-core) are required prerequisites. Build and [publish](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-publish?tabs=netcore21#synopsis) the `deploy-cromwell-on-azure` project [as a self-contained deployment with your target RID](https://docs.microsoft.com/en-us/dotnet/core/deploying/#self-contained-deployments-scd) to produce the executable*
+### Optional: build the executable yourself
+Note: Build instructions only provided for the latest release.
+
+#### Linux
+*Preqrequisites*:<br/>
+.NET Core 3.1 SDK for [Linux](https://docs.microsoft.com/en-us/dotnet/core/install/linux). Get instructions for your Linux distro and version to install the SDK. 
+
+For example, instructions for *Ubuntu 18.04* are available [here](https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#1804-) and below for convenience:
+
+```
+wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt-get update && \
+sudo apt-get install -y apt-transport-https && \
+sudo apt-get update && \
+sudo apt-get install -y dotnet-sdk-3.1
+```
+
+#### Windows
+*Preqrequisites*:<br/>
+.NET Core 3.1 SDK for [Windows](https://dotnet.microsoft.com/download). Get the executable and follow the wizard to install the SDK.
+
+*Recommended*:<br/>
+VS 2019
+
+#### Build steps
+1. Clone the [Cromwell on Azure repository](https://github.com/microsoft/CromwellOnAzure)
+2. Build the solution using `dotnet build` on bash or Powershell. For Windows, you can choose to build and test using VS 2019
+3. Run tests using `dotnet test` on bash or Powershell
+4. [Publish](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#synopsis) the `deploy-cromwell-on-azure` project [as a self-contained deployment with your target runtime identifier (RID)](https://docs.microsoft.com/en-us/dotnet/core/deploying/#self-contained-deployments-scd) to produce the executable
+
+Example<br/> 
+Linux: `dotnet publish -r linux-x64`:<br/>
+Windows: `dotnet publish -r win-x64`:<br/>
+
+Learn more about `dotnet` commands [here](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet#dotnet-commands)
 
 ### Run the deployment executable
 
@@ -70,7 +109,9 @@ Run the following at the command line or terminal after navigating to where your
 .\deploy-cromwell-on-azure.exe --SubscriptionId 00000000-0000-0000-0000-000000000000 --RegionName westus2 --MainIdentifierPrefix coa 
 ```
 
-Deployment can take up to 25 minutes to complete. **At installation, a user is created to allow managing the host VM with username "vmadmin". The password is randomly generated and shown during installation. You may want to save the username, password and resource group name to allow for advanced debugging later.**
+A [test workflow](#Hello-World-WDL-test) is run to ensure successful deployment. If your [Batch account does not have enough resource quotas](https://docs.microsoft.com/en-us/azure/batch/batch-quota-limit#resource-quotas), you will see the error while deploying. You can request more quotas by following [these instructions](https://docs.microsoft.com/en-us/azure/batch/batch-quota-limit#increase-a-quota).
+
+Deployment, including a small test workflow can take up to 25 minutes to complete. **At installation, a user is created to allow managing the host VM with username "vmadmin". The password is randomly generated and shown during installation. You may want to save the username, password and resource group name to allow for advanced debugging later.**
 
 Prepare, start or abort a workflow using instructions [here](docs/managing-your-workflow.md).
 
@@ -78,9 +119,9 @@ Prepare, start or abort a workflow using instructions [here](docs/managing-your-
 
 Once deployed, Cromwell on Azure configures the following Azure resources:
 
-* [Host VM](https://azure.microsoft.com/en-us/services/virtual-machines/) - runs [Ubuntu 16.04 LTS](https://github.com/microsoft/CromwellOnAzure/blob/421ccd163bfd53807413ed696c0dab31fb2478aa/src/deploy-cromwell-on-azure/Configuration.cs#L16) and [Docker Compose with four containers](https://github.com/microsoft/CromwellOnAzure/blob/master/src/deploy-cromwell-on-azure/scripts/docker-compose.yml) (Cromwell, MySQL, TES, TriggerService).  [Blobfuse](https://github.com/Azure/azure-storage-fuse) is used to mount the default storage account as a local file system available to the four containers.  Also created are an OS and data disk, network interface, public IP address, virtual network, and network security group. [Learn more](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/)
+* [Host VM](https://azure.microsoft.com/en-us/services/virtual-machines/) - runs [Ubuntu 18.04 LTS](https://github.com/microsoft/CromwellOnAzure/blob/421ccd163bfd53807413ed696c0dab31fb2478aa/src/deploy-cromwell-on-azure/Configuration.cs#L16) and [Docker Compose with four containers](https://github.com/microsoft/CromwellOnAzure/blob/master/src/deploy-cromwell-on-azure/scripts/docker-compose.yml) (Cromwell, MySQL, TES, TriggerService).  [Blobfuse](https://github.com/Azure/azure-storage-fuse) is used to mount the default storage account as a local file system available to the four containers.  Also created are an OS and data disk, network interface, public IP address, virtual network, and network security group. [Learn more](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/)
 * [Batch account](https://docs.microsoft.com/en-us/azure/batch/) - The Azure Batch account is used by TES to spin up the virtual machines that run each task in a workflow.  After deployment, create an Azure support request to increase your core quotas if you plan on running large workflows.  [Learn more](https://docs.microsoft.com/en-us/azure/batch/batch-quota-limit#resource-quotas)
-* [Storage account](https://docs.microsoft.com/en-us/azure/storage/) - The Azure Storage account is mounted to the host VM using [blobfuse](https://github.com/Azure/azure-storage-fuse), which enables [Azure Block Blobs](https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs) to be mounted as a local file system available to the four containers running in Docker. By default, it includes the following Blob containers - `cromwell-executions`, `cromwell-workflow-logs`, `inputs`, `outputs`, and `workflows`.
+* [Storage account](https://docs.microsoft.com/en-us/azure/storage/) - The Azure Storage account is mounted to the host VM using [blobfuse](https://github.com/Azure/azure-storage-fuse), which enables [Azure Block Blobs](https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs) to be mounted as a local file system available to the four containers running in Docker. By default, it includes the following Blob containers - `configuration`, `cromwell-executions`, `cromwell-workflow-logs`, `inputs`, `outputs`, and `workflows`.
 * [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) - This contains logs from TES and the Trigger Service to enable debugging.
 * [Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/introduction) - This database is used by TES, and includes information and metadata about each TES task that is run as part of a workflow.
 
@@ -92,9 +133,19 @@ You can [follow these steps](/docs/troubleshooting-guide.md/#Use-input-data-file
 
 ### Connect to existing Azure resources I own that are not part of the Cromwell on Azure instance by default
 
-Cromwell on Azure uses [managed identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to allow the host VM to connect to Azure resources in a simple and secure manner.  At the time of installation, a managed identity is created and associated with the host VM. You can find the identity via the Azure Portal by searching for the VM name in Azure Active Directory, under "All Applications". Or you may use Azure CLI `show` command as described [here](https://docs.microsoft.com/en-us/cli/azure/vm/identity?view=azure-cli-latest#az-vm-identity-show).
+Cromwell on Azure uses [managed identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to allow the host VM to connect to Azure resources in a simple and secure manner.  
 
-To allow the host VM to connect to **custom** Azure resources like Storage Account, Batch Account etc. you can use the [Azure Portal](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) or [Azure CLI](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli) to find the managed identity of the host VM and add it as a Contributor to the required Azure resource.<br/>
+At the time of installation, a managed identity is created and associated with the host VM. 
+
+**Cromwell on Azure version 2.x**
+
+Since version 2.0, a user managed identity is created with the name `{resource-group-name}-identity` in the deployment resource group.
+
+**Cromwell on Azure version 1.x**
+
+For version 1.x and below, a system managed identity is created. You can find the identity via the Azure Portal by searching for the VM name in Azure Active Directory, under "All Applications". Or you may use Azure CLI `show` command as described [here](https://docs.microsoft.com/en-us/cli/azure/vm/identity?view=azure-cli-latest#az-vm-identity-show).
+
+To allow the host VM to connect to **custom** Azure resources like Storage Account, Batch Account etc. you can use the [Azure Portal](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) or [Azure CLI](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli) to find the managed identity of the host VM (if using Cromwell on Azure version 1.x) or the user-managed identity (if using Cromwell on Azure version 2.x and above) and add it as a Contributor to the required Azure resource.<br/>
 
 ![Add Role](/docs/screenshots/add-role.png)
 
@@ -154,6 +205,8 @@ Hello World trigger JSON file as seen in your storage account's `workflows` cont
   "WorkflowDependenciesUrl": null
 }
 ```
+
+If your "Hello-World" test workflow or other workflows consistently fail, make sure to [check your Azure Batch account quotas](docs/troubleshooting-guide.md/#Check-Azure-Batch-account-quotas).
 
 ## Run Common Workflows
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
  * Here is an example workflow to [convert FASTQ files to uBAM files](docs/example-fastq-to-ubam.md/#Example-workflow-to-convert-FASTQ-files-to-uBAM-files)<br/>
  * Have an existing WDL file that you want to run on Azure? [Modify your existing WDL with these adaptations for Azure](docs/change-existing-WDL-for-Azure.md/#How-to-modify-an-existing-WDL-file-to-run-on-Cromwell-on-Azure)<br/>
  * Want to run commonly used workflows? [Find links to ready-to-use workflows here](#Run-Common-Workflows)<br/>
- * Are there any examples of tertiary analysis or other genomics analysis? [Find links to related project here](#Related-Projects)<br/>
+ * Want to see some examples of tertiary analysis or other genomics analysis? [Find links to related project here](#Related-Projects)<br/>
 
 #### Questions?
- * See our [Troubleshooting Guide](docs/troubleshooting-guide.md/#FAQs,-advanced-troubleshooting-and-known-issues-for-Cromwell-on-Azure) for more information.<br/>
+ * See our [Troubleshooting Guide](docs/troubleshooting-guide.md/#FAQs,-advanced-troubleshooting-and-known-issues-for-Cromwell-on-Azure) for more information<br/>
  * Known issues and work-arounds are [documented here](docs/troubleshooting-guide.md/#Known-Issues-And-Mitigation)<br/>
 
 If you are running into an issue and cannot find any information in the troubleshooting guide, please open a GitHub issue!<br/>

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -205,7 +205,7 @@ string   ApplicationInsightsAccountName | Y | N | N |  The name of the Applicat
 string   VmName | Y | N | Y | Name of the VM host that is part of the Cromwell on Azure deployment to update - Required for update if multiple VMs exist in the resource group
 string   CromwellVersion | Y | N | Y |  Cromwell docker image version to use
 bool     SkipTestWorkflow = false; | Y | Y | Y |  Set to true to skip running the default [test workflow](../README.md/#Hello-World-WDL-test)
-bool     Update =   false; | Y | Y | Y | Required for update
+bool     Update =   false; | Y | Y | Y | Set to true if you want to [update your existing Cromwell on Azure deployment](/release-notes/2.0.0.md/#Update-instructions) to the latest version. Required for update
 
 
 ### Use a specific Cromwell version

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -8,7 +8,8 @@ This article answers FAQs, describes advanced features that allow customization 
    * How can I [upgrade my Cromwell on Azure instance?](#Upgrade-my-Cromwell-on-Azure-instance)
 
 2. Analysis
-   * I submitted a job and it failed almost immediately. What [happened to it](#Job-failed-immediately)?   
+   * I submitted a job and it failed almost immediately. What [happened to it](#Job-failed-immediately)?
+   * I can only run small workflows but not workflows that require multiple tasks with a large total cpu cores requirement. [How do I increase workflows capacity?](#Check-Azure-Batch-account-quotas)
    * How do I [setup my own WDL](#Set-up-my-own-WDL) to run on Cromwell?
    * How can I see [how far along my workflow has progressed?](#Check-all-tasks-running-for-a-workflow-using-Batch-account)
    * My workflow failed at task X. Where should I look to determine why it failed?
@@ -17,10 +18,12 @@ This article answers FAQs, describes advanced features that allow customization 
    * My jobs are taking a long time in the "Preparing" task state, even with "smaller" input files and VMs being used. [Why is that](#Check-Azure-Storage-Tier)?
 
 3. Customizing your instance
+   * How can I [customize my Cromwell on Azure deployment?](#Customize-your-Cromwell-on-Azure-deployment)
+   * How can I [use a specific Cromwell image version?](#Use-a-specific-Cromwell-version)
    * How do I [use input data files for my workflows from a different Azure Storage account](#Use-input-data-files-from-an-existing-Storage-account-that-my-lab-or-team-is-currently-using) that my lab or team is currently using?
    * Can I connect a different [batch account with previously increased quotas](#Use-a-batch-account-for-which-I-have-already-requested-or-received-increased-cores-quota-from-Azure-Support) to run my workflows?
    * How can I [use private Docker containers for my workflows?](#Use-private-docker-containers-hosted-on-Azure)
-   * A lot of tasks for my workflows run longer than 24 hours and have been randomly stopped. How can I [run all my tasks on dedicated batch VMs](#Configure-my-Cromwell-on-Azure-instance-to-always-use-dedicated-Batch-VMs-to-avoid-getting-preempted)
+   * A lot of tasks for my workflows run longer than 24 hours and have been randomly stopped. How can I [run all my tasks on dedicated batch VMs?](#Configure-my-Cromwell-on-Azure-instance-to-always-use-dedicated-Batch-VMs-to-avoid-getting-preempted)
    * Can I get [direct access to Cromwell's REST API?](#Access-the-Cromwell-REST-API-directly-from-Linux-host-VM)
 
 4. Performance & Optimization
@@ -54,20 +57,31 @@ After the change, **sr=c&si=inputs-key** should be the order in your SAS URL. <b
 Update all the SAS URLs similarly and retry your workflow.
 
 ### All TES tasks for my workflow are done running, but the trigger JSON file is still in the "inprogress" directory in the workflows container
-The root cause is most likely memory pressure on the host Linux VM because [blobfuse](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux#overview) processes grow to consume all physical memory. 
+
+1. The root cause is most likely memory pressure on the host Linux VM because [blobfuse](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux#overview) processes grow to consume all physical memory. 
 
 You may see the following Cromwell container logs as a symptom:
 > Cromwell shutting down because it cannot access the database):
 Shutting down cromid-5bd1d24 as at least 15 minutes of heartbeat write errors have occurred between 2020-02-18T22:03:01.110Z and 2020-02-18T22:19:01.111Z (16.000016666666667 minutes
 
-OR
-> Failed to instantiate Cromwell System. Shutting down Cromwell.
-liquibase.exception.LockException: Could not acquire change log lock.  Currently locked by 012ec19c3285 (172.18.0.4) since 2/19/20 4:10 PM
-
 To mitigate, please resize your VM in the resource group to a machine with at least 14GB memory/RAM. Any workflows still in progress will not be affected.
 
 ![Resize VM](/docs/screenshots/resize-VM.png)
 
+2. Another possible scenario is that the "mysql" database is in an unusable state, which means Cromwell cannot continue processing workflows.
+
+You may see the following Cromwell container logs as a symptom:
+> Failed to instantiate Cromwell System. Shutting down Cromwell.
+liquibase.exception.LockException: Could not acquire change log lock.  Currently locked by 012ec19c3285 (172.18.0.4) since 2/19/20 4:10 PM
+
+**Note: This has been fixed in Release 2.1. If you use the 2.1 deployer or update to this version, you can skip the mitigation steps below**
+
+For Release 2.0 and below:
+To mitigate, log on to the host VM and execute the following and then restart the VM:
+
+```
+sudo docker exec -it cromwellazure_mysqldb_1 bash -c 'mysql -ucromwell -Dcromwell_db -pcromwell -e"SELECT * FROM DATABASECHANGELOGLOCK;UPDATE DATABASECHANGELOGLOCK SET LOCKED=0, LOCKGRANTED=null, LOCKEDBY=null where ID=1;SELECT * FROM DATABASECHANGELOGLOCK;"'
+```
 
 ## Setup
 ### Setup Cromwell on Azure for multiple users in the same Azure subscription
@@ -85,7 +99,7 @@ Starting in version 1.x, for convenience, some configuration files are hosted on
 
 ## Analysis
 ### Job failed immediately
-If a workflow you start has a task that failed immediately and lead to workflow failure, be sure to check your input JSON files. Follow the instructions [here](managing-your-workflow.md/#How-to-prepare-an-inputs-JSON-file-to-use-in-your-workflow) and check out an example WDL and inputs JSON file [here](example-fastq-to-ubam.md/#Configure-your-Cromwell-on-Azure-trigger-JSON,-inputs-JSON-and-WDL-files) to ensure there are no errors in defining your input files.
+If a workflow you start has a task that failed immediately and lead to workflow failure be sure to check your input JSON files. Follow the instructions [here](managing-your-workflow.md/#How-to-prepare-an-inputs-JSON-file-to-use-in-your-workflow) and check out an example WDL and inputs JSON file [here](example-fastq-to-ubam.md/#Configure-your-Cromwell-on-Azure-trigger-JSON,-inputs-JSON-and-WDL-files) to ensure there are no errors in defining your input files.
 
 > For files hosted on an Azure Storage account that is connected to your Cromwell on Azure instance, the input path consists of 3 parts - the storage account name, the blob container name, file path with extension, following this format:
 ```
@@ -98,6 +112,13 @@ If a workflow you start has a task that failed immediately and lead to workflow 
 Another possibility is that you are trying to use a storage account that hasn't been mounted to your Cromwell on Azure instance - either by [default during setup](../README.md/#Cromwell-on-Azure-deployed-resources) or by following these steps to [mount a different storage account](#Use-input-data-files-from-an-existing-Storage-account-that-my-lab-or-team-is-currently-using). <br/>
 
 Check out these [known issues and mitigation](#Known-Issues-And-Mitigation) for more commonly seen issues caused by bugs we are actively tracking.
+
+### Check Azure Batch account quotas
+
+If you are running a task in a workflow with a large cpu cores requirement, check if your [Batch account has enough resource quotas](https://docs.microsoft.com/en-us/azure/batch/batch-quota-limit#resource-quotas). You can request more quotas by following [these instructions](https://docs.microsoft.com/en-us/azure/batch/batch-quota-limit#increase-a-quota).
+
+For other resource quotas, like active jobs or pools, if there are not enough resources available, Cromwell on Azure keeps the tasks in queue until resources become available.
+This may lead to longer wait times for workflow completion.
 
 ### Set up my own WDL
 To get started you can view this [Hello World sample](../README.md/#Hello-World-WDL-test), an [example WDL](example-fastq-to-ubam.md) to convert FASTQ to UBAM or [follow these steps](change-existing-WDL-for-Azure.md) to convert an existing public WDL for other clouds to run on Azure. <br/>
@@ -154,6 +175,83 @@ Paste the ssh connection string in a command line, PowerShell or terminal applic
 
 ![Connect with SSH](/docs/screenshots/connectssh.PNG)
 
+### Customize your Cromwell on Azure deployment
+Before deploying, you can choose to customize some input parameters to use existing Azure resources. Example:
+
+```
+.\deploy-cromwell-on-azure.exe --SubscriptionId <Your subscription ID> --RegionName <Your region> --MainIdentifierPrefix <Your string> --VmSize "Standard_D2_v2"
+```
+
+Here is the summary of all configuration parameters:
+
+Configuration   parameter | Has default | Validated | Used by update | Comment
+-- | -- | -- | -- | --
+string   SubscriptionId | N | Y | Y | Always required
+string   RegionName = "westus"; | Y | Y | N | Required for new   install
+string   MainIdentifierPrefix = "coa"; | Y | Y | N |  
+string   VmOsVersion = "18.04-LTS"; | Y | N | N |  
+string   VmSize   = "Standard_D3_v2"; | Y | N | N |  
+string   VnetAddressSpace = "10.0.0.0/24"; | Y | N | N |  
+string   VmUsername = "vmadmin"; | Y | N | Y |  
+string   VmPassword | Y | N | Y | Required for update
+string   ResourceGroupName | Y | Y | Y | Required for update.   If provided for new install, it must already exist.
+string   BatchAccountName | Y | N | N |  
+string   StorageAccountName | Y | N | N |  
+string   NetworkSecurityGroupName | Y | N | N |  
+string   CosmosDbAccountName | Y | N | N |  
+string   ApplicationInsightsAccountName | Y | N | N |  
+string   VmName | Y | N | Y | Required for update   if multiple VMs exist in the resource group
+bool     Silent | Y | Y | Y | Integration testing
+bool     DeleteResourceGroupOnFailure | Y | Y | N | Integration testing
+string   CromwellVersion | Y | N | Y |  
+string   TesImageName | Y | N | Y | Integration testing
+string   TriggerServiceImageName | Y | N | Y | Integration testing
+string   CustomCromwellImagePath | N | N | Y | Development
+string   CustomTesImagePath | N | N | Y | Development
+string   CustomTriggerServiceImagePath | N | N | Y | Development
+bool     SkipTestWorkflow = false; | Y | Y | Y |  
+bool     Update =   false; | Y | Y | Y | Required for update
+
+
+### Use a specific Cromwell version
+
+#### Before deploying Cromwell on Azure
+
+To choose a specific Cromwell version, you can specify the version as a configuration parameter before deploying Cromwell on Azure. Here is an example:
+
+```
+.\deploy-cromwell-on-azure.exe --SubscriptionId <Your subscription ID> --RegionName <Your region> --MainIdentifierPrefix <Your string> --CromwellVersion 53
+```
+
+#### After Cromwell on Azure has been deployed
+
+After deployment, you can still change the Cromwell docker image version being used.
+[Log on to the host VM](#Connect-to-the-host-VM-that-runs-all-the-docker-containers) using the ssh connection string as described in the instructions. 
+
+**Cromwell on Azure version 2.x**
+
+Starting with version 2.0, the Cromwell docker image version is pinned to "broadinstitute/cromwell:50".
+
+Replace `CromwellImageName` variable in the `env-03-external-images.txt` file with the name and tag of the docker image of your choice save your changes.<br/>
+
+```
+cd /data/cromwellazure/
+sudo nano env-03-external-images.txt
+# Modify the CromwellImageName to your Batch Account name and save the file
+```
+
+**Cromwell on Azure version 1.x**
+
+Replace image name with the tag of your choice for the "cromwell" service in the `docker-compose.yml` file.<br/>
+
+```
+cd /data/cromwellazure/
+sudo nano docker-compose.yml
+# Modify the cromwell service image name and save the file
+```
+
+For these changes to take effect, be sure to restart your Cromwell on Azure VM through the Azure Portal UI or run `sudo reboot`. or run `sudo reboot`. You can also restart the docker containers.
+
 ### Use input data files from an existing storage account that my lab or team is currently using
 Navigate to the "configuration" container in the Cromwell on Azure Storage account. Replace YOURSTORAGEACCOUNTNAME with your storage account name and YOURCONTAINERNAME with your container name in the `containers-to-mount` file below:
 ```
@@ -173,13 +271,28 @@ When using the newly mounted storage account in your inputs JSON file, use the p
 For these changes to take effect, be sure to restart your Cromwell on Azure VM through the Azure Portal UI.
 
 ### Use a batch account for which I have already requested or received increased cores quota from Azure Support
-[Log on to the host VM](#Connect-to-the-host-VM-that-runs-all-the-docker-containers) using the ssh connection string as described in the instructions. Replace `BatchAccountName` environment variable for the "tes" service in the `docker-compose.yml` file with the name of the desired batch account and save your changes.<br/>
+[Log on to the host VM](#Connect-to-the-host-VM-that-runs-all-the-docker-containers) using the ssh connection string as described in the instructions. 
+
+**Cromwell on Azure version 2.x**
+
+Replace `BatchAccountName` variable in the `env-01-account-names.txt` file with the name of the desired batch account and save your changes.<br/>
 
 ```
-cd /cromwellazure/
+cd /data/cromwellazure/
+sudo nano env-01-account-names.txt
+# Modify the BatchAccountName to your Batch Account name and save the file
+```
+
+**Cromwell on Azure version 1.x**
+
+Replace `BatchAccountName` environment variable for the "tes" service in the `docker-compose.yml` file with the name of the desired batch account and save your changes.<br/>
+
+```
+cd /data/cromwellazure/
 sudo nano docker-compose.yml
 # Modify the BatchAccountName to your Batch Account name and save the file
 ```
+
 To allow the host VM to use a batch account, [add the VM identity as a Contributor](../README.md/#Connect-to-existing-Azure-resources-I-own-that-are-not-part-of-the-Cromwell-on-Azure-instance-by-default) to the Azure batch account via Azure Portal or Azure CLI.<br/>
 To allow the host VM to read prices and information about types of machines available for the batch account, [add the VM identity as a Billing Reader](../README.md/#Connect-to-existing-Azure-resources-I-own-that-are-not-part-of-the-Cromwell-on-Azure-instance-by-default) to the subscription with the configured Batch Account.
 
@@ -192,13 +305,28 @@ To allow the host VM to use an ACR, [add the VM identity as a Contributor](../RE
 ### Configure my Cromwell on Azure instance to always use dedicated batch VMs to avoid getting preempted
 By default, we are using an environment variable `UsePreemptibleVmsOnly` set to true, to always use low priority Azure batch nodes.<br/>
 
-If you prefer to use dedicated Azure Batch nodes for all tasks, [log on to the host VM](#Connect-to-the-host-VM-that-runs-all-the-docker-containers) using the ssh connection string as described in the instructions. Replace `UsePreemptibleVmsOnly` environment variable for the "tes" service to "false" in the `docker-compose.yml` file and save your changes.<br/>
+If you prefer to use dedicated Azure Batch nodes for all tasks, [log on to the host VM](#Connect-to-the-host-VM-that-runs-all-the-docker-containers) using the ssh connection string as described in the instructions. 
+
+**Cromwell on Azure version 2.x**
+
+Change the `UsePreemptibleVmsOnly` variable in the `env-04-settings.txt` file and save your changes.<br/>
 
 ```
-cd /cromwellazure/
+cd /data/cromwellazure/
+sudo nano env-04-settings.txt
+# Modify UsePreemptibleVmsOnly to false and save the file
+```
+
+**Cromwell on Azure version 1.x**
+
+Change the `UsePreemptibleVmsOnly` environment variable for the "tes" service to "false" in the `docker-compose.yml` file and save your changes.<br/>
+
+```
+cd /data/cromwellazure/
 sudo nano docker-compose.yml
 # Modify UsePreemptibleVmsOnly to false and save the file
 ```
+
 Note that, you can set this for each task individually by using the `preemptible` boolean flag set to `true` or `false` in the "runtime" attributes section of your task. The `preemptible` runtime attribute will overwrite the `UsePreemptibleVmsOnly` environment variable setting for a particular task.<br/>
 For these changes to take effect, be sure to restart your Cromwell on Azure VM through the Azure Portal UI or run `sudo reboot`.
 

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -188,10 +188,10 @@ Configuration   parameter | Has default | Validated | Used by update | Comment
 -- | -- | -- | -- | --
 string   SubscriptionId | N | Y | Y | Azure Subscription Id - Always required
 string   RegionName = "westus"; | Y | Y | N | Azure region name to deploy to - Required for new install
-string   MainIdentifierPrefix = "coa"; | Y | Y | N |  Prefix for all resources to be deployed - Required to deploy but defaults to "coa"
-string   VmOsVersion = "18.04-LTS"; | Y | N | N |  OS Version of the Linux Ubuntu VM to use as the host - Not required and defaults to Ubuntu 18.04 LTS
-string   VmSize   = "Standard_D3_v2"; | Y | N | N |  VM size of the Linux Ubuntu VM to use as the host - Not required and defaults to [Standard_D3_v2](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv2-series)
-string   VmUsername = "vmadmin"; | Y | N | Y |  Username created on Cromwell on Azure Linux host - Not required and defaults to "vmadmin"
+string   MainIdentifierPrefix = "coa"; | Y | Y | N | Prefix for all resources to be deployed - Required to deploy but defaults to "coa"
+string   VmOsVersion = "18.04-LTS"; | Y | N | N | OS Version of the Linux Ubuntu VM to use as the host - Not required and defaults to Ubuntu 18.04 LTS
+string   VmSize   = "Standard_D3_v2"; | Y | N | N | VM size of the Linux Ubuntu VM to use as the host - Not required and defaults to [Standard_D3_v2](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv2-series)
+string   VmUsername = "vmadmin"; | Y | N | Y | Username created on Cromwell on Azure Linux host - Not required and defaults to "vmadmin"
 string   VmPassword | Y | N | Y | Required for update
 string   VnetResourceGroupName | Y | Y | N | Available starting version 2.1. The resource group name of the specified virtual network to use - Not required, generated automatically if not provided. If specified, VnetName and SubnetName must be provided.
 string   VnetName | Y | Y | N | Available starting version 2.1. The name of the specified virtual network to use - Not required, generated automatically if not provided. If specified, VnetResourceGroupName and SubnetName must be provided.
@@ -199,12 +199,12 @@ string   SubnetName | Y | Y | N | Available starting version 2.1. The subnet nam
 string   ResourceGroupName | Y | Y | Y | Required for update.   If provided for new Cromwell on Azure deployment, it must already exist.
 string   BatchAccountName | Y | N | N | The name of the Azure Batch Account to use ; must be in the SubscriptionId provided - Not required, generated automatically if not provided
 string   StorageAccountName | Y | N | N | The name of the Azure Storage Account to use ; must be in the SubscriptionId provided - Not required, generated automatically if not provided
-string   NetworkSecurityGroupName | Y | N | N |  The name of the Network Security Group to use; must be in the SubscriptionId provided - Not required, generated automatically if not provided
+string   NetworkSecurityGroupName | Y | N | N | The name of the Network Security Group to use; must be in the SubscriptionId provided - Not required, generated automatically if not provided
 string   CosmosDbAccountName | Y | N | N | The name of the Cosmos Db Account to use; must be in the SubscriptionId provided - Not required, generated automatically if not provided
-string   ApplicationInsightsAccountName | Y | N | N |  The name of the Application Insights Account to use; must be in the SubscriptionId provided - Not required, generated automatically if not provided
+string   ApplicationInsightsAccountName | Y | N | N | The name of the Application Insights Account to use; must be in the SubscriptionId provided - Not required, generated automatically if not provided
 string   VmName | Y | N | Y | Name of the VM host that is part of the Cromwell on Azure deployment to update - Required for update if multiple VMs exist in the resource group
-string   CromwellVersion | Y | N | Y |  Cromwell docker image version to use
-bool     SkipTestWorkflow = false; | Y | Y | Y |  Set to true to skip running the default [test workflow](../README.md/#Hello-World-WDL-test)
+string   CromwellVersion | Y | N | Y | Cromwell docker image version to use
+bool     SkipTestWorkflow = false; | Y | Y | Y | Set to true to skip running the default [test workflow](../README.md/#Hello-World-WDL-test)
 bool     Update =   false; | Y | Y | Y | Set to true if you want to [update your existing Cromwell on Azure deployment](/release-notes/2.0.0.md/#Update-instructions) to the latest version. Required for update
 
 

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -186,30 +186,25 @@ Here is the summary of all configuration parameters:
 
 Configuration   parameter | Has default | Validated | Used by update | Comment
 -- | -- | -- | -- | --
-string   SubscriptionId | N | Y | Y | Always required
-string   RegionName = "westus"; | Y | Y | N | Required for new   install
-string   MainIdentifierPrefix = "coa"; | Y | Y | N |  
-string   VmOsVersion = "18.04-LTS"; | Y | N | N |  
-string   VmSize   = "Standard_D3_v2"; | Y | N | N |  
-string   VnetAddressSpace = "10.0.0.0/24"; | Y | N | N |  
-string   VmUsername = "vmadmin"; | Y | N | Y |  
+string   SubscriptionId | N | Y | Y | Azure Subscription Id - Always required
+string   RegionName = "westus"; | Y | Y | N | Azure region name to deploy to - Required for new install
+string   MainIdentifierPrefix = "coa"; | Y | Y | N |  Prefix for all resources to be deployed - Required to deploy but defaults to "coa"
+string   VmOsVersion = "18.04-LTS"; | Y | N | N |  OS Version of the Linux Ubuntu VM to use as the host - Not required and defaults to Ubuntu 18.04 LTS
+string   VmSize   = "Standard_D3_v2"; | Y | N | N |  VM size of the Linux Ubuntu VM to use as the host - Not required and defaults to [Standard_D3_v2](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv2-series)
+string   VmUsername = "vmadmin"; | Y | N | Y |  Username created on Cromwell on Azure Linux host - Not required and defaults to "vmadmin"
 string   VmPassword | Y | N | Y | Required for update
-string   ResourceGroupName | Y | Y | Y | Required for update.   If provided for new install, it must already exist.
-string   BatchAccountName | Y | N | N |  
-string   StorageAccountName | Y | N | N |  
-string   NetworkSecurityGroupName | Y | N | N |  
-string   CosmosDbAccountName | Y | N | N |  
-string   ApplicationInsightsAccountName | Y | N | N |  
-string   VmName | Y | N | Y | Required for update   if multiple VMs exist in the resource group
-bool     Silent | Y | Y | Y | Integration testing
-bool     DeleteResourceGroupOnFailure | Y | Y | N | Integration testing
-string   CromwellVersion | Y | N | Y |  
-string   TesImageName | Y | N | Y | Integration testing
-string   TriggerServiceImageName | Y | N | Y | Integration testing
-string   CustomCromwellImagePath | N | N | Y | Development
-string   CustomTesImagePath | N | N | Y | Development
-string   CustomTriggerServiceImagePath | N | N | Y | Development
-bool     SkipTestWorkflow = false; | Y | Y | Y |  
+string   VnetResourceGroupName | Y | Y | N | Available starting version 2.1. The resource group name of the specified virtual network to use - Not required, generated automatically if not provided. If specified, VnetName and SubnetName must be provided.
+string   VnetName | Y | Y | N | Available starting version 2.1. The name of the specified virtual network to use - Not required, generated automatically if not provided. If specified, VnetResourceGroupName and SubnetName must be provided.
+string   SubnetName | Y | Y | N | Available starting version 2.1. The subnet name of the specified virtual network to use - Not required, generated automatically if not provided. If specified, VnetResourceGroupName and VnetName must be provided.
+string   ResourceGroupName | Y | Y | Y | Required for update.   If provided for new Cromwell on Azure deployment, it must already exist.
+string   BatchAccountName | Y | N | N | The name of the Azure Batch Account to use ; must be in the SubscriptionId provided - Not required, generated automatically if not provided
+string   StorageAccountName | Y | N | N | The name of the Azure Storage Account to use ; must be in the SubscriptionId provided - Not required, generated automatically if not provided
+string   NetworkSecurityGroupName | Y | N | N |  The name of the Network Security Group to use; must be in the SubscriptionId provided - Not required, generated automatically if not provided
+string   CosmosDbAccountName | Y | N | N | The name of the Cosmos Db Account to use; must be in the SubscriptionId provided - Not required, generated automatically if not provided
+string   ApplicationInsightsAccountName | Y | N | N |  The name of the Application Insights Account to use; must be in the SubscriptionId provided - Not required, generated automatically if not provided
+string   VmName | Y | N | Y | Name of the VM host that is part of the Cromwell on Azure deployment to update - Required for update if multiple VMs exist in the resource group
+string   CromwellVersion | Y | N | Y |  Cromwell docker image version to use
+bool     SkipTestWorkflow = false; | Y | Y | Y |  Set to true to skip running the default [test workflow](../README.md/#Hello-World-WDL-test)
 bool     Update =   false; | Y | Y | Y | Required for update
 
 


### PR DESCRIPTION
Addresses most of #70 

- Add instructions to use a specific Cromwell docker image
- Add a note for users to check quotas for their batch account - number of accounts per subscription may be limited https://github.com/microsoft/CromwellOnAzure/issues/62#issuecomment-607990402 
- Add instructions on how to configure CoA deployment e.g.: VmSize https://github.com/microsoft/CromwellOnAzure/issues/101#issuecomment-638300686
https://github.com/microsoft/CromwellOnAzure/issues/125#issuecomment-673150362
- Add compilation instructions for linux https://github.com/microsoft/CromwellOnAzure/issues/91
- Add Cromwell db lock known issue https://github.com/microsoft/CromwellOnAzure/issues/57
- Update instructions and all docs based on v2.0