### PR TITLE
Use image version "2" for TES and TriggerService

### DIFF
--- a/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
@@ -1,2 +1,2 @@
-TesImageName=mcr.microsoft.com/cromwellonazure/tes:2
-TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:2
+TesImageName=mcr.microsoft.com/cromwellonazure/tes:2.1.0
+TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:2.1.0

--- a/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
@@ -1,2 +1,2 @@
-﻿TesImageName=mcr.microsoft.com/cromwellonazure/tes:2.0.0
-TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:2.0.0
+TesImageName=mcr.microsoft.com/cromwellonazure/tes:2
+TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:2


### PR DESCRIPTION
Use image tag "2" to always pull latest 2.x image version