### PR TITLE
Updated default docker tags for TES and TriggerService

### DIFF
--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -6,5 +6,5 @@
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("2.0.0")]
-[assembly: AssemblyFileVersion("2.0.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/src/deploy-cromwell-on-azure/scripts/env-00-coa-version.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-00-coa-version.txt
@@ -1,1 +1,1 @@
-﻿CromwellOnAzureVersion=2.1.0
+﻿CromwellOnAzureVersion=2.1

--- a/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
@@ -1,2 +1,2 @@
-﻿TesImageName=mcr.microsoft.com/cromwellonazure/tes:2.0.0
-TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:2.0.0
+﻿TesImageName=mcr.microsoft.com/cromwellonazure/tes:2
+TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:2


### PR DESCRIPTION
Updated default docker tags for TES and TriggerService to point to latest public images, so locally built deployer can be used without having to specify TesImageName and TriggerServiceImageName options. Updated the CromwellOnAzureVersion to include just the major and minor parts as those are the only ones used by the update logic. Updated versions in CommonAssemblyInfo.cs to "0.0.0.0" to hint that those don't have to be updated manually. All of the above versions are replaced with four-part version during the official build.