### PR TITLE
users may specify existing Storage/Batch accounts at deployment; Storage accounts accept https traffic only

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -192,14 +192,8 @@ namespace CromwellOnAzureDeployer
                         throw new ValidationException($"Could not retrieve the Batch account name from virtual machine {configuration.VmName}.");
                     }
 
-                    batchAccount = (await new BatchManagementClient(tokenCredentials) { SubscriptionId = configuration.SubscriptionId }.BatchAccount.ListByResourceGroupAsync(configuration.ResourceGroupName))
-                        .FirstOrDefault(a => a.Name.Equals(batchAccountName, StringComparison.OrdinalIgnoreCase));
-
-                    if (batchAccount == null)
-                    {
-                        batchAccount = (await TryGetExistingBatchAccountAsync(batchAccountName))
-                                ?? throw new ValidationException($"Batch account {batchAccountName} does not exist in subscription {configuration.SubscriptionId}.");
-                    }
+                    batchAccount = await TryGetExistingBatchAccountAsync(batchAccountName)
+                            ?? throw new ValidationException($"Batch account {batchAccountName} does not exist in subscription {configuration.SubscriptionId}.");
 
                     configuration.BatchAccountName = batchAccountName;
 
@@ -208,14 +202,8 @@ namespace CromwellOnAzureDeployer
                         throw new ValidationException($"Could not retrieve the default storage account name from virtual machine {configuration.VmName}.");
                     }
 
-                    storageAccount = (await azureClient.StorageAccounts.ListByResourceGroupAsync(configuration.ResourceGroupName))
-                        .FirstOrDefault(a => a.Name.Equals(storageAccountName, StringComparison.OrdinalIgnoreCase));
-
-                    if (storageAccount == null)
-                    {
-                        storageAccount = await TryGetExistingStorageAccountAsync(storageAccountName)
-                                ?? throw new ValidationException($"Storage account {storageAccountName} does not exist in subscription {configuration.SubscriptionId}.");
-                    }
+                    storageAccount = await TryGetExistingStorageAccountAsync(storageAccountName)
+                            ?? throw new ValidationException($"Storage account {storageAccountName} does not exist in subscription {configuration.SubscriptionId}.");
 
                     configuration.StorageAccountName = storageAccountName;
 
@@ -1052,8 +1040,7 @@ namespace CromwellOnAzureDeployer
         {
             return Execute(
                 $"Creating Batch Account: {configuration.BatchAccountName}...",
-                async () =>
-                    await TryGetExistingBatchAccountAsync() ?? await CreateNewBatchAccount()
+                async () => await TryGetExistingBatchAccountAsync() ?? await CreateNewBatchAccount()
                 );
         }
 

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1401,6 +1401,23 @@ namespace CromwellOnAzureDeployer
             ValidateSubscriptionId(configuration.SubscriptionId);
             ValidateRegionName(configuration.RegionName);
             ValidateMainIdentifierPrefix(configuration.MainIdentifierPrefix);
+            if (configuration.Update)
+            {
+                ValidateUpdateScenario();
+            }
+        }
+
+        private void ValidateUpdateScenario()
+        {
+            if (configuration.StorageAccountName != null)
+            {
+                throw new ValidationException("invalid to specify StorageAccountName in an Update scenario");
+            }
+
+            if (configuration.BatchAccountName != null)
+            {
+                throw new ValidationException("invalid to specify BatchAccountName in an Update scenario");
+            }
         }
 
         private static void DisplayValidationExceptionAndExit(ValidationException validationException)

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -804,7 +804,7 @@ namespace CromwellOnAzureDeployer
         private Task<IStorageAccount> CreateStorageAccountAsync()
         {
             return Execute(
-                $"Creating Storage Account: {configuration.StorageAccountName}...",
+                $"Finding Existing Storage Account or Creating New Storage Account: {configuration.StorageAccountName}...",
                 async () =>
                 {
                     var storageAccount = await TryGetExistingStorageAccountAsync() ?? await CreateNewStorageAccountAsync();
@@ -1039,7 +1039,7 @@ namespace CromwellOnAzureDeployer
         private Task<BatchAccount> CreateBatchAccountAsync()
         {
             return Execute(
-                $"Creating Batch Account: {configuration.BatchAccountName}...",
+                $"Finding Existing Batch Account or Creating New Batch Account: {configuration.BatchAccountName}...",
                 async () => await TryGetExistingBatchAccountAsync() ?? await CreateNewBatchAccount()
                 );
         }

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -806,7 +806,7 @@ namespace CromwellOnAzureDeployer
         private Task<IStorageAccount> GetOrCreateStorageAccountAsync()
         {
             return Execute(
-                (existingStorageAccount == null ? $"Creating New" : $"Using Existing") + " Storage Account: {configuration.StorageAccountName}...",
+                (existingStorageAccount == null ? "Creating" : "Using existing") + $" Storage Account: {configuration.StorageAccountName}...",
                 async () =>
                 {
                     var storageAccount = existingStorageAccount ??
@@ -1027,7 +1027,7 @@ namespace CromwellOnAzureDeployer
         private Task<BatchAccount> GetOrCreateBatchAccountAsync()
         {
             return Execute(
-                (existingBatchAccount == null ? $"Creating New" : "Using Existing") + $" Batch Account: {configuration.BatchAccountName}...",
+                (existingBatchAccount == null ? "Creating" : "Using existing") + $" Batch Account: {configuration.BatchAccountName}...",
                 async () => existingBatchAccount ?? 
                     await new BatchManagementClient(tokenCredentials) { SubscriptionId = configuration.SubscriptionId }
                         .BatchAccount
@@ -1266,7 +1266,7 @@ namespace CromwellOnAzureDeployer
 
                 if (existingBatchAccount == null)
                 {
-                    throw new ValidationException($"If BatchAccountName is provided, the storage account must already exist in subscription {configuration.SubscriptionId} and region {configuration.RegionName}, and be accessible to the user.", displayExample: false);
+                    throw new ValidationException($"If BatchAccountName is provided, the batch account must already exist in subscription {configuration.SubscriptionId} and region {configuration.RegionName}, and be accessible to the user.", displayExample: false);
                 }
             }
 


### PR DESCRIPTION
The following PR relates to the following issues

https://github.com/microsoft/CromwellOnAzure/issues/150
https://github.com/microsoft/CromwellOnAzure/issues/158
https://github.com/microsoft/CromwellOnAzure/issues/159

Issues 150 and 159 relate to the usage of already existing storage and batch accounts when provided.  I have tested that the accounts are used properly both in deployment and upgrade scenarios.  As a final test, I made sure that one couldn't deploy with a batch account for which the user was not an owner.

The two issues are handled in basically the same way, and so they are together in this PR.

Issue 158 relates to allowing only https traffic to storage accounts.  I had intended to make 158 a separate PR, but it's a one line fix that would have had merge issues if it was in a separate PR, so instead it is here.