### PR TITLE
Deprecating msgenpublicdata for new 2.2 installs and commenting it out during upgrade to 2.2

### DIFF
--- a/src/deploy-cromwell-on-azure/scripts/containers-to-mount
+++ b/src/deploy-cromwell-on-azure/scripts/containers-to-mount
@@ -28,6 +28,5 @@
 
 # Optional containers, should list all containers where your input files are located:
 
-https://msgenpublicdata.blob.core.windows.net/inputs?sv=2015-04-05&sr=c&si=coa&sig=pENt%2FMMOj24uoNBZIPLa%2BNVVkvopcFK51rwADyYLEPE%3D
 /{DefaultStorageAccountName}/inputs
 https://datasettestinputs.blob.core.windows.net/dataset?sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D


### PR DESCRIPTION
Deprecating msgenpublicdata for new 2.2 installs and commenting it out during upgrade of existing installations to 2.2. Will remove it completely in 2.3