### PR TITLE
fix bug in VnetResourceGroupName error message

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1360,7 +1360,7 @@ namespace CromwellOnAzureDeployer
 
             if (string.IsNullOrWhiteSpace(configuration.VnetName) ^ string.IsNullOrWhiteSpace(configuration.VnetResourceGroupName))
             {
-                throw new ValidationException("Both VnetResourceGroup and VnetName are required when using the existing virtual network.");
+                throw new ValidationException("Both VnetResourceGroupName and VnetName are required when using the existing virtual network.");
             }
 
             var vnet = await azureSubscriptionClient.Networks.GetByResourceGroupAsync(configuration.VnetResourceGroupName, configuration.VnetName);


### PR DESCRIPTION
An error message was "Both VnetResourceGroup and VnetName are required when using the existing virtual network."  Changed "VnetResourceGroup" to "VnetResourceGroupName"