### PR TITLE
Update deployer's test trigger file to use WorkflowInputsUrls to remove ambiguity

### DIFF
--- a/src/Common/ExcludeObsoletePropertiesContractResolver.cs
+++ b/src/Common/ExcludeObsoletePropertiesContractResolver.cs
@@ -1,0 +1,38 @@
+﻿// License: https://creativecommons.org/licenses/by-sa/4.0/
+// Derived from: https://stackoverflow.com/a/56694483 (author: https://stackoverflow.com/users/10263/brian-rogers)
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Common
+{
+    public class ExcludeObsoletePropertiesContractResolver : DefaultContractResolver
+    {
+        /// <summary>
+        /// Prevents serialization of properties that are marked obsolete
+        /// </summary>
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+
+            if (property.AttributeProvider.GetAttributes(inherit: true).OfType<ObsoleteAttribute>().Any())
+            {
+                property.ShouldSerialize = _ => false;
+            }
+
+            return property;
+        }
+
+        public static JsonSerializerSettings GetSettings()
+        {
+            return new JsonSerializerSettings
+            {
+                ContractResolver = new ExcludeObsoletePropertiesContractResolver(),
+                Formatting = Formatting.Indented
+            };
+        }
+    }
+}

--- a/src/Common/Workflow.cs
+++ b/src/Common/Workflow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Common
@@ -8,6 +9,7 @@ namespace Common
     public class Workflow
     {
         public string WorkflowUrl { get; set; }
+        [Obsolete("For backwards compatibility only; please use WorkflowInputsUrls instead")]
         public string WorkflowInputsUrl { get; set; }
         public List<string> WorkflowInputsUrls { get; set; }
         public string WorkflowOptionsUrl { get; set; }

--- a/src/deploy-cromwell-on-azure.Tests/CromwellOnAzureDeployerTests.cs
+++ b/src/deploy-cromwell-on-azure.Tests/CromwellOnAzureDeployerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Common;
 using Microsoft.Rest.Azure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -30,6 +31,14 @@ namespace CromwellOnAzureDeployer.Tests
             CloudException exception = null;
             var error = exception.ToCloudErrorType();
             Assert.IsTrue(error == CloudErrorType.NotSet);
+        }
+
+        [TestMethod]
+        public void SerializingTriggerFileExcludesObsoleteProperties()
+        {
+            var workflow = new Workflow();
+            var json = JsonConvert.SerializeObject(workflow, ExcludeObsoletePropertiesContractResolver.GetSettings());
+            Assert.IsFalse(json.Contains("\"WorkflowInputsUrl\""));
         }
     }
 }

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1579,7 +1579,7 @@ namespace CromwellOnAzureDeployer
             var workflowTrigger = new Workflow
             {
                 WorkflowUrl = $"/{storageAccount.Name}/{InputsContainerName}/{testDirectoryName}/{wdlFileName}",
-                WorkflowInputsUrl = $"/{storageAccount.Name}/{InputsContainerName}/{testDirectoryName}/{workflowInputsFileName}"
+                WorkflowInputsUrls = new List<string> { $"/{storageAccount.Name}/{InputsContainerName}/{testDirectoryName}/{workflowInputsFileName}" }
             };
 
             await UploadTextToStorageAccountAsync(storageAccount, InputsContainerName, $"{testDirectoryName}/{wdlFileName}", wdlFileContent);

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1585,7 +1585,7 @@ namespace CromwellOnAzureDeployer
             await UploadTextToStorageAccountAsync(storageAccount, InputsContainerName, $"{testDirectoryName}/{wdlFileName}", wdlFileContent);
             await UploadTextToStorageAccountAsync(storageAccount, InputsContainerName, $"{testDirectoryName}/{workflowInputsFileName}", workflowInputsFileContent);
             await UploadTextToStorageAccountAsync(storageAccount, InputsContainerName, $"{testDirectoryName}/{inputFileName}", inputFileContent);
-            await UploadTextToStorageAccountAsync(storageAccount, WorkflowsContainerName, $"new/{id}.json", JsonConvert.SerializeObject(workflowTrigger, Formatting.Indented));
+            await UploadTextToStorageAccountAsync(storageAccount, WorkflowsContainerName, $"new/{id}.json", JsonConvert.SerializeObject(workflowTrigger, ExcludeObsoletePropertiesContractResolver.GetSettings()));
 
             return await IsWorkflowSuccessfulAfterLongPollingAsync(storageAccount, WorkflowsContainerName, id);
         }


### PR DESCRIPTION
- Updates the deployer's test trigger file to use `WorkflowInputsUrls`
- Marks `WorkflowInputsUrl` as obsolete (but keeps it for backwards compatibility) and prevents its serialization