### PR TITLE
Fixing the issue where upgrade from 1.x to 2.1+ fails 

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -58,6 +58,7 @@ namespace CromwellOnAzureDeployer
         private const string ContainersToMountFileName = "containers-to-mount";
         private const string InputsContainerName = "inputs";
         private const string CromwellAzureRootDir = "/data/cromwellazure";
+        private const string CromwellAzureRootDirSymLink = "/cromwellazure";    // This path is present in all CoA versions
 
         private readonly CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -662,7 +663,7 @@ namespace CromwellOnAzureDeployer
         {
             if (configuration.Update)
             {
-                await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"cd {CromwellAzureRootDir} && sudo docker-compose down");
+                await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"cd {CromwellAzureRootDirSymLink} && sudo docker-compose down");
             }
 
             await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"echo '{configuration.VmPassword}' | sudo -S -p '' /bin/bash -c \"echo '{configuration.VmUsername} ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/z_{configuration.VmUsername}\"");


### PR DESCRIPTION
Fixing bug #186 where upgrade from 1.x to 2.1+ fails due to the missing/data/cromwellazure directory. 