### PR TITLE
Logging "Cromwell is available" message

### DIFF
--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Common
+{
+    public static class Constants
+    {
+        public static string CromwellIsAvailableMessage = "Cromwell is available.";
+    }
+}

--- a/src/TriggerService/TriggerEngine.cs
+++ b/src/TriggerService/TriggerEngine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Common;
 using Microsoft.Extensions.Logging;
 
 namespace TriggerService
@@ -74,16 +75,9 @@ namespace TriggerService
 
         private async Task WaitForCromwellToBecomeAvailableAsync()
         {
-            var isCromwellAvailable = await environment.IsCromwellAvailableAsync();
-
-            if (isCromwellAvailable)
-            {
-                return;
-            }
-
             var haveLoggedOnce = false;
 
-            while (!isCromwellAvailable)
+            while (!await environment.IsCromwellAvailableAsync())
             {
                 if (!haveLoggedOnce)
                 {
@@ -92,10 +86,9 @@ namespace TriggerService
                 }
 
                 await Task.Delay(availabilityWaitTime);
-                isCromwellAvailable = await environment.IsCromwellAvailableAsync();
             }
 
-            logger.LogInformation($"Cromwell is available.");
+            logger.LogInformation(Constants.CromwellIsAvailableMessage);
         }
 
         private async Task WaitForAzureStorageToBecomeAvailableAsync()

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -529,7 +529,7 @@ namespace CromwellOnAzureDeployer
                 {
                     while (!cts.IsCancellationRequested)
                     {
-                        var (isCromwellAvailable, _, _) = await ExecuteCommandOnVirtualMachineWithRetriesAsync(sshConnectionInfo, "[ $(sudo docker logs cromwellazure_triggerservice_1 | grep -c 'Cromwell is available.') -gt 0 ] && echo 1 || echo 0");
+                        var (isCromwellAvailable, _, _) = await ExecuteCommandOnVirtualMachineWithRetriesAsync(sshConnectionInfo, $"[ $(sudo docker logs cromwellazure_triggerservice_1 | grep -c '{Constants.CromwellIsAvailableMessage}') -gt 0 ] && echo 1 || echo 0");
 
                         if (isCromwellAvailable == "1")
                         {


### PR DESCRIPTION
Logging "Cromwell is available" message if Cromwell is available immediately when Trigger Service starts. This fixes the issue where deployer gets stuck waiting for this message during installation.