### PR TITLE
Update managing-your-workflow.md

### DIFF
--- a/docs/managing-your-workflow.md
+++ b/docs/managing-your-workflow.md
@@ -15,8 +15,8 @@ In order to run a WDL file, you must modify/create a workflow with the following
 ```
 runtime {
     cpu: 1
-    memory: 2 GB
-    disk: 10 GB
+    memory: "2 GB"
+    disk: "10 GB"
     docker:
     maxRetries: 0
     preemptible: true


### PR DESCRIPTION
Add quotes to memory and disk values or else Cromwell fails at the workflow parsing step.