### PR TITLE
Fixing the bug where update hangs due to unbound variable error in startup.sh.

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1704,7 +1704,8 @@ namespace CromwellOnAzureDeployer
                 var (output, _, _) = await sshClient.ExecuteCommandAsync($"sudo mkdir -p {dir} && owner=$(stat -c '%U' {dir}) && mask=$(stat -c '%a' {dir}) && ownerCanWrite=$(( (16#$mask & 16#200) > 0 )) && othersCanWrite=$(( (16#$mask & 16#002) > 0 )) && ( [[ $owner == $(whoami) && $ownerCanWrite == 1 || $othersCanWrite == 1 ]] && echo 0 || ( sudo chmod o+w {dir} && echo 1 ))");
                 var dirWasMadeWritableToOthers = output == "1";
 
-                await sshClient.ExecuteCommandAsync($"sudo touch {remoteFilePath} && owner=$(stat -c '%U' {remoteFilePath}) && mask=$(stat -c '%a' {remoteFilePath}) && ownerCanWrite=$(( (16#$mask & 16#200) > 0 )) && othersCanWrite=$(( (16#$mask & 16#002) > 0 )) && ( [[ $owner == $(whoami) && $ownerCanWrite == 1 || $othersCanWrite == 1 ]] && echo 0 || ( sudo chmod o+w {remoteFilePath} && echo 1 ))");
+                // Make the destination file writable for the current user. The user running the update might not be the same user that created the file.
+                await sshClient.ExecuteCommandAsync($"sudo touch {remoteFilePath} && sudo chmod o+w {remoteFilePath}");
                 await sftpClient.UploadFileAsync(input, remoteFilePath, true);
                 await sshClient.ExecuteCommandAsync($"sudo chmod o-w {remoteFilePath}");
 

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -661,6 +661,8 @@ namespace CromwellOnAzureDeployer
 
         private async Task ConfigureVmAsync(ConnectionInfo sshConnectionInfo)
         {
+            // If the user was added or password reset via Azure portal, assure that the user will not be prompted
+            // for password on each command and make bash the default shell.
             await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"echo '{configuration.VmPassword}' | sudo -S -p '' /bin/bash -c \"echo '{configuration.VmUsername} ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/z_{configuration.VmUsername}\"");
             await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo usermod --shell /bin/bash {configuration.VmUsername}");
 

--- a/src/deploy-cromwell-on-azure/scripts/startup.sh
+++ b/src/deploy-cromwell-on-azure/scripts/startup.sh
@@ -63,7 +63,8 @@ do
             subscription_ids=( $(grep -Po '"id":"/subscriptions/\K([^"]*)' <<< $content) )
 
             write_log "Getting list of accessible resources..."
-            resource_ids=()
+            # Initializing array with single empty string to avoid unbound variable error in bash version < 4.4
+            resource_ids=("")
 
             for subscription_id in "${subscription_ids[@]}"
             do


### PR DESCRIPTION
This happens when running 2.2 update on top of CoA instance that was initially installed on Ubuntu 16.04 (CoA versions 1.x), even if the system was updated to 2.x afterwards. The startup script exits with an error and system does not start. Also enabled updating with username different than the one used for initial install. Fixes #194