### PR TITLE
Disabled MySQL binary logging to conserve space on the data disk.

### DIFF
--- a/src/deploy-cromwell-on-azure/scripts/docker-compose.yml
+++ b/src/deploy-cromwell-on-azure/scripts/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - /bin/sh
       - -c
     command: ["ln -sf /mysql-init/init-user.sql /docker-entrypoint-initdb.d/init_user.sql \
-      && docker-entrypoint.sh mysqld --init-file /mysql-init/unlock-change-log.sql"]
+      && docker-entrypoint.sh mysqld --init-file /mysql-init/unlock-change-log.sql --disable-log-bin"]
     expose:
       - "3306"
     restart: unless-stopped


### PR DESCRIPTION
No new MySQL binary logs will be produced. Users may delete the old ones to reclaim disk space. 
Closes #204