### PR TITLE
Fixed the logic that determines the top WorkflowId from TES Task properties

### DIFF
--- a/src/TesApi.Tests/TaskServiceApiControllerTests.cs
+++ b/src/TesApi.Tests/TaskServiceApiControllerTests.cs
@@ -71,7 +71,7 @@ namespace TesApi.Tests
             {
                 Description = taskDescription,
                 Executors = new List<TesExecutor> { new TesExecutor { Image = "ubuntu" } },
-                Inputs = new List<TesInput> { new TesInput { Path = $"/cromwell-executions/test/{cromwellWorkflowId}/call-hello/test-subworkflow/{cromwellSubWorkflowId}/call-subworkflow/shard-8/execution/script" } }
+                Inputs = new List<TesInput> { new TesInput { Name = "commandScript", Path = $"/cromwell-executions/test/{cromwellWorkflowId}/call-hello/test-subworkflow/{cromwellSubWorkflowId}/call-subworkflow/shard-8/execution/script" } }
             };
 
             var controller = this.GetTaskServiceApiController();
@@ -245,14 +245,15 @@ namespace TesApi.Tests
         [TestMethod]
         public async Task CreateTaskAsync_ExtractsWorkflowId()
         {
-            var cromwellWorkflowId = "daf1a044-d741-4db9-8eb5-d6fd0519b1f1";
-            var taskDescription = $"{cromwellWorkflowId}:BackendJobDescriptorKey_CommandCallNode_wf_hello.hello:-1:1";
+            var cromwellWorkflowId = Guid.NewGuid().ToString();
+            var cromwellSubWorkflowId = Guid.NewGuid().ToString();
+            var taskDescription = $"{cromwellSubWorkflowId}:BackendJobDescriptorKey_CommandCallNode_wf_hello.hello:-1:1";
 
             var tesTask = new TesTask()
             {
                 Description = taskDescription,
                 Executors = new List<TesExecutor> { new TesExecutor { Image = "ubuntu" } },
-                Inputs = new List<TesInput> { new TesInput { Path = "/cromwell-executions/test/daf1a044-d741-4db9-8eb5-d6fd0519b1f1/call-hello/execution/script" } }
+                Inputs = new List<TesInput> { new TesInput { Name = "commandScript", Path = $"/cromwell-executions/test/{cromwellWorkflowId}/call-hello/test-subworkflow/{cromwellSubWorkflowId}/call-subworkflow/shard-8/execution/script" } }
             };
 
             var controller = this.GetTaskServiceApiController();
@@ -455,7 +456,7 @@ namespace TesApi.Tests
             {
                 Name = "test.cwl",
                 Executors = new List<TesExecutor> { new TesExecutor { Image = "ubuntu" } },
-                Inputs = new List<TesInput> { new TesInput { Path = "/cromwell-executions/test.cwl/daf1a044-d741-4db9-8eb5-d6fd0519b1f1/call-hello/execution/script" } },
+                Inputs = new List<TesInput> { new TesInput { Name = "commandScript", Path = "/cromwell-executions/test.cwl/daf1a044-d741-4db9-8eb5-d6fd0519b1f1/call-hello/execution/script" } },
                 Resources = tesResourcesReceivedFromCromwell
             };
 

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -125,7 +125,7 @@ namespace TesApi.Controllers
             // example: /cromwell-executions/test/daf1a044-d741-4db9-8eb5-d6fd0519b1f1/call-hello/execution/script
             tesTask.WorkflowId = tesTask
                 ?.Inputs
-                ?.FirstOrDefault(i => i?.Path?.StartsWith(rootExecutionPath, StringComparison.OrdinalIgnoreCase) == true)
+                ?.FirstOrDefault(i => i?.Name?.Equals("commandScript", StringComparison.OrdinalIgnoreCase) == true)
                 ?.Path
                 ?.Split('/', StringSplitOptions.RemoveEmptyEntries)
                 ?.Skip(2)


### PR DESCRIPTION
If the first input points to a file in /cromwell-executions directory, the workflow id of that input file was incorrectly used to determine the currently executing task's workflow_id. The fix pulls it out from the commandScript path.
