### PR TITLE
Alternate reboot strategy for the deployer

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -802,9 +802,9 @@ namespace CromwellOnAzureDeployer
             }
         }
 
-        private async Task RebootVmAsync(ConnectionInfo sshConnectionInfo)
+        private Task RebootVmAsync(ConnectionInfo sshConnectionInfo)
         {
-            await Execute(
+            return Execute(
                 "Rebooting VM...",
                 async () =>
                 {

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -384,7 +384,7 @@ namespace CromwellOnAzureDeployer
                 }
 
                 await WriteCoaVersionToVmAsync(sshConnectionInfo);
-                await RestartVmAsync(linuxVm);
+                await RebootVmAsync(sshConnectionInfo);
                 await WaitForSshConnectivityAsync(sshConnectionInfo);
 
                 if (!await IsStartupSuccessfulAsync(sshConnectionInfo))
@@ -802,15 +802,11 @@ namespace CromwellOnAzureDeployer
             }
         }
 
-        private Task RestartVmAsync(IVirtualMachine linuxVm)
+        private Task RebootVmAsync(ConnectionInfo sshConnectionInfo)
         {
             return Execute(
-                "Restarting VM...",
-                async () =>
-                {
-                    await linuxVm.RestartAsync(cts.Token);
-                    return Task.CompletedTask;
-                });
+                "Rebooting VM...",
+                () => ExecuteCommandOnVirtualMachineWithRetriesAsync(sshConnectionInfo, $"sudo reboot"));
         }
 
         private Task AssignVmAsDataReaderToStorageAccountAsync(IIdentity managedIdentity, IStorageAccount storageAccount)

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -802,11 +802,21 @@ namespace CromwellOnAzureDeployer
             }
         }
 
-        private Task RebootVmAsync(ConnectionInfo sshConnectionInfo)
+        private async Task RebootVmAsync(ConnectionInfo sshConnectionInfo)
         {
-            return Execute(
+            await Execute(
                 "Rebooting VM...",
-                () => ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, "nohup sudo -b bash -c 'reboot' &>/dev/null"));
+                async () =>
+                {
+                    try
+                    {
+                        await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, "nohup sudo -b bash -c 'reboot' &>/dev/null");
+                    }
+                    catch (SshConnectionException)
+                    {
+                        return;
+                    }
+                });
         }
 
         private Task AssignVmAsDataReaderToStorageAccountAsync(IIdentity managedIdentity, IStorageAccount storageAccount)

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -806,7 +806,7 @@ namespace CromwellOnAzureDeployer
         {
             return Execute(
                 "Rebooting VM...",
-                () => ExecuteCommandOnVirtualMachineWithRetriesAsync(sshConnectionInfo, $"sudo reboot"));
+                () => ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, "nohup sudo -b bash -c 'reboot' &>/dev/null"));
         }
 
         private Task AssignVmAsDataReaderToStorageAccountAsync(IIdentity managedIdentity, IStorageAccount storageAccount)


### PR DESCRIPTION
Previously, the deployer called an ARM REST API to instruct Azure to reboot the VM at the end of the deployment work.  However, it appears that occasionally Azure does not actually reboot the VM, which results in the deployer hanging.

This change is to directly execute the "reboot" command within the OS itself to initiate the reboot.