### PR TITLE
modified AzureProxy.cs and DefaultVmPrices.json to do instance selection for Ddv4 machinetypes

### DIFF
--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -767,6 +767,11 @@ namespace TesApi.Web
         private static IEnumerable<string> GetVmSizesSupportedByBatch()
         {
             return new List<string> {
+                "Standard_D2d_v4",
+                "Standard_D4d_v4",
+                "Standard_D8d_v4",
+                "Standard_D16d_v4",
+                "Standard_F48s_v2",
                 "Standard_A1",
                 "Standard_A1_v2",
                 "Standard_A10",

--- a/src/TesApi.Web/DefaultVmPrices.json
+++ b/src/TesApi.Web/DefaultVmPrices.json
@@ -2472,5 +2472,45 @@
     ],
     "PricePerHour": 0.122,
     "LowPriority": true
+  },
+{
+    "VmSizes": [
+      "Standard_D2d_v4"
+    ],
+    "VmSeries": [
+      "Ddv4"
+    ],
+    "PricePerHour": 0.122,
+    "LowPriority": true
+  },
+{
+    "VmSizes": [
+      "Standard_D4d_v4"
+    ],
+    "VmSeries": [
+      "Ddv4"
+    ],
+    "PricePerHour": 0.122,
+    "LowPriority": true
+  },
+{
+    "VmSizes": [
+      "Standard_D8d_v4"
+    ],
+    "VmSeries": [
+      "Ddv4"
+    ],
+    "PricePerHour": 0.122,
+    "LowPriority": true
+  },
+{
+    "VmSizes": [
+      "Standard_D16d_v4"
+    ],
+    "VmSeries": [
+      "Ddv4"
+    ],
+    "PricePerHour": 0.122,
+    "LowPriority": true
   }
 ]


### PR DESCRIPTION
The logic to chose the Ddv4 machine types can be added to BatchScheduler.cs file.