### PR TITLE
Improve logging for private ACRs and update documentation

### DIFF
--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -321,7 +321,7 @@ For these changes to take effect, be sure to restart your Cromwell on Azure VM t
 
 ### Use private Docker containers hosted on Azure
 Cromwell on Azure supports private Docker images for your WDL tasks hosted on [Azure Container Registry or ACR](https://docs.microsoft.com/en-us/azure/container-registry/).
-To allow the host VM to use an ACR, [add the VM identity as a Contributor](../README.md/#Connect-to-existing-Azure-resources-I-own-that-are-not-part-of-the-Cromwell-on-Azure-instance-by-default) to the Container Registry via Azure Portal or Azure CLI.<br/>
+To allow the host VM to use an ACR, [add the VM identity as a Contributor](../README.md/#Connect-to-existing-Azure-resources-I-own-that-are-not-part-of-the-Cromwell-on-Azure-instance-by-default) to the Container Registry via the Azure Portal or Azure CLI.  Also, set "Admin user" to "Enabled" in the ACR's "Access keys" section in the Azure Portal.<br/>
 
 ### Configure my Cromwell on Azure instance to always use dedicated batch VMs to avoid getting preempted
 By default, your workflows will run on low priority Azure batch nodes.<br/>

--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -473,7 +473,7 @@ namespace TesApi.Web
                 }
                 catch (Exception ex)
                 {
-                    logger.LogWarning($"TES service has no permission to list container registries in subscription {subId}.  Exception: {ex}");
+                    logger.LogWarning($"TES service doesn't have permission to list container registries in subscription {subId}.  Exception: {ex}");
                     continue;
                 }
 
@@ -487,7 +487,7 @@ namespace TesApi.Web
                     }
                     catch (Exception ex)
                     {
-                        logger.LogWarning($"TES service has no permission to get credentials for registry {r.LoginServerUrl}.  Please verify that 'Admin user' is enabled in the 'Access Keys' area in the Azure Portal for this container registry.  Exception: {ex}");
+                        logger.LogWarning($"TES service doesn't have permission to get credentials for registry {r.LoginServerUrl}.  Please verify that 'Admin user' is enabled in the 'Access Keys' area in the Azure Portal for this container registry.  Exception: {ex}");
                     }
                 }
             }

--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -465,7 +465,7 @@ namespace TesApi.Web
 
             foreach (var subId in subscriptionIds)
             {
-                List<IRegistry> registries;
+                var registries = new List<IRegistry>();
 
                 try
                 {


### PR DESCRIPTION
When TES does not have access to an ACR, the logs could be misleading.  Also, the docs did not specify that "Admin user" needs to be enabled for the ACR.