### PR TITLE
Added background service to clean up the "orphaned" Batch jobs

### DIFF
--- a/src/TesApi.Tests/BatchSchedulerTests.cs
+++ b/src/TesApi.Tests/BatchSchedulerTests.cs
@@ -207,6 +207,7 @@ namespace TesApi.Tests
             Assert.AreEqual(TesState.SYSTEMERROREnum, await GetNewTesTaskStateAsync(TesState.RUNNINGEnum, BatchJobAndTaskStates.MoreThanOneJobFound));
             Assert.AreEqual(TesState.EXECUTORERROREnum, await GetNewTesTaskStateAsync(TesState.RUNNINGEnum, BatchJobAndTaskStates.NodeDiskFull));
             Assert.AreEqual(TesState.QUEUEDEnum, await GetNewTesTaskStateAsync(TesState.RUNNINGEnum, BatchJobAndTaskStates.ActiveJobWithMissingAutoPool));
+            Assert.AreEqual(TesState.QUEUEDEnum, await GetNewTesTaskStateAsync(TesState.RUNNINGEnum, BatchJobAndTaskStates.NodePreempted));
         }
 
         [TestMethod]
@@ -224,6 +225,7 @@ namespace TesApi.Tests
             Assert.AreEqual(TesState.QUEUEDEnum, await GetNewTesTaskStateAsync(TesState.INITIALIZINGEnum, BatchJobAndTaskStates.NodeAllocationFailed));
             Assert.AreEqual(TesState.EXECUTORERROREnum, await GetNewTesTaskStateAsync(TesState.INITIALIZINGEnum, BatchJobAndTaskStates.ImageDownloadFailed));
             Assert.AreEqual(TesState.QUEUEDEnum, await GetNewTesTaskStateAsync(TesState.INITIALIZINGEnum, BatchJobAndTaskStates.ActiveJobWithMissingAutoPool));
+            Assert.AreEqual(TesState.QUEUEDEnum, await GetNewTesTaskStateAsync(TesState.INITIALIZINGEnum, BatchJobAndTaskStates.NodePreempted));
         }
 
         [TestMethod]
@@ -799,6 +801,7 @@ namespace TesApi.Tests
             public static AzureBatchJobAndTaskState TaskNotFound => new AzureBatchJobAndTaskState { JobState = JobState.Active, TaskState = null };
             public static AzureBatchJobAndTaskState MoreThanOneJobFound => new AzureBatchJobAndTaskState { MoreThanOneActiveJobFound = true };
             public static AzureBatchJobAndTaskState NodeAllocationFailed => new AzureBatchJobAndTaskState { JobState = JobState.Active, NodeAllocationFailed = true };
+            public static AzureBatchJobAndTaskState NodePreempted => new AzureBatchJobAndTaskState { JobState = JobState.Active, NodeState = ComputeNodeState.Preempted };
             public static AzureBatchJobAndTaskState NodeDiskFull => new AzureBatchJobAndTaskState { JobState = JobState.Active, NodeErrorCode = "DiskFull" };
             public static AzureBatchJobAndTaskState ActiveJobWithMissingAutoPool => new AzureBatchJobAndTaskState { ActiveJobWithMissingAutoPool = true };
             public static AzureBatchJobAndTaskState ImageDownloadFailed => new AzureBatchJobAndTaskState { JobState = JobState.Active, NodeErrorCode = "ContainerInvalidImage" };

--- a/src/TesApi.Tests/DeleteOrphanedBatchJobsHostedServiceTests.cs
+++ b/src/TesApi.Tests/DeleteOrphanedBatchJobsHostedServiceTests.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Tes.Models;
+using Tes.Repository;
+using TesApi.Web;
+
+namespace TesApi.Tests
+{
+    [TestClass]
+    public class DeleteOrphanedBatchJobsHostedServiceTests
+    {
+        private static readonly TimeSpan minJobAge = TimeSpan.FromHours(1);
+
+        [TestMethod]
+        public async Task DeleteOrphanedBatchJobs_DeletesJobs_TesStateCompleted()
+        {
+            // Arrange & Act
+            var firstTesTask = new TesTask { Id = "tesTaskId1", State = TesState.COMPLETEEnum };
+            var secondTesTask = new TesTask { Id = "tesTaskId2", State = TesState.RUNNINGEnum };
+            var thirdTesTask = new TesTask { Id = "tesTaskId3", State = TesState.INITIALIZINGEnum };
+            var azureProxy = await ArrangeTest(new[] { firstTesTask, secondTesTask, thirdTesTask });
+
+            // Assert
+            azureProxy.Verify(i => i.ListOrphanedJobsToDeleteAsync(minJobAge));
+            azureProxy.Verify(i => i.DeleteBatchJobAsync("tesTaskId1"));
+            azureProxy.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task DeleteOrphanedBatchJobs_DeletesJobs_TesStateError()
+        {
+            // Arrange & Act
+            var firstTesTask = new TesTask { Id = "tesTaskId1", State = TesState.SYSTEMERROREnum };
+            var secondTesTask = new TesTask { Id = "tesTaskId2", State = TesState.EXECUTORERROREnum };
+            var thirdTesTask = new TesTask { Id = "tesTaskId3", State = TesState.PAUSEDEnum };
+            var azureProxy = await ArrangeTest(new[] { firstTesTask, secondTesTask, thirdTesTask });
+
+            // Assert
+            azureProxy.Verify(i => i.ListOrphanedJobsToDeleteAsync(minJobAge));
+            azureProxy.Verify(i => i.DeleteBatchJobAsync("tesTaskId1"));
+            azureProxy.Verify(i => i.DeleteBatchJobAsync("tesTaskId2"));
+            azureProxy.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task DeleteOrphanedBatchJobs_DeletesJobs_TesStateCanceled()
+        {
+            // Arrange & Act
+            var firstTesTask = new TesTask { Id = "tesTaskId1", State = TesState.CANCELEDEnum };
+            var secondTesTask = new TesTask { Id = "tesTaskId2", State = TesState.QUEUEDEnum };
+            var thirdTesTask = new TesTask { Id = "tesTaskId3", State = TesState.INITIALIZINGEnum };
+            var azureProxy = await ArrangeTest(new[] { firstTesTask, secondTesTask, thirdTesTask });
+
+            // Assert
+            azureProxy.Verify(i => i.ListOrphanedJobsToDeleteAsync(minJobAge));
+            azureProxy.Verify(i => i.DeleteBatchJobAsync("tesTaskId1"));
+            azureProxy.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task DeleteOrphanedBatchJobs_DeletesJobs_TesStateUnknown()
+        {
+            // Arrange & Act
+            var firstTesTask = new TesTask { Id = "tesTaskId1", State = TesState.UNKNOWNEnum };
+            var secondTesTask = new TesTask { Id = "tesTaskId2", State = TesState.PAUSEDEnum };
+            var thirdTesTask = new TesTask { Id = "tesTaskId3", State = TesState.RUNNINGEnum };
+            var azureProxy = await ArrangeTest(new[] { firstTesTask, secondTesTask, thirdTesTask });
+
+            // Assert
+            azureProxy.Verify(i => i.ListOrphanedJobsToDeleteAsync(minJobAge));
+            azureProxy.Verify(i => i.DeleteBatchJobAsync("tesTaskId1"));
+            azureProxy.VerifyNoOtherCalls();
+        }
+
+        private async Task<Mock<IAzureProxy>> ArrangeTest(TesTask[] tasks)
+        {
+            var azureProxy = new Mock<IAzureProxy>();
+            var mockRepo = new Mock<IRepository<TesTask>>();
+
+            azureProxy.Setup(p => p.ListOrphanedJobsToDeleteAsync(minJobAge)).ReturnsAsync(tasks.Select(i => i.Id + "-1"));
+
+            foreach (var item in tasks)
+            {
+                mockRepo.Setup(repo => repo.TryGetItemAsync(item.Id, It.IsAny<Action<TesTask>>()))
+                    .Callback<string, Action<TesTask>>((id, action) =>
+                    {
+                        action(item);
+                    })
+                    .ReturnsAsync(true);
+            }
+
+            var deleteOrphanedBatchJobsHostedService = new DeleteOrphanedBatchJobsHostedService(
+                azureProxy.Object,
+                mockRepo.Object,
+                new NullLogger<DeleteOrphanedBatchJobsHostedService>());
+
+            await deleteOrphanedBatchJobsHostedService.StartAsync(new System.Threading.CancellationToken());
+
+            return azureProxy;
+        }
+    }
+}

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -118,7 +118,7 @@ namespace TesApi.Web
                 new TesTaskStateTransition(tesTaskIsQueuedInitializingOrRunning, BatchTaskState.NodeUnusable, DeleteBatchJobAndSetTaskExecutorErrorAsync),
                 new TesTaskStateTransition(tesTaskIsInitializingOrRunning, BatchTaskState.JobNotFound, SetTaskSystemError),
                 new TesTaskStateTransition(tesTaskIsInitializingOrRunning, BatchTaskState.MissingBatchTask, DeleteBatchJobAndSetTaskSystemErrorAsync),
-                new TesTaskStateTransition(tesTaskIsInitializingOrRunning, BatchTaskState.NodePreempted, DeleteBatchJobAndRequeueTaskAsync) // TODO: Implement preemption detection
+                new TesTaskStateTransition(tesTaskIsInitializingOrRunning, BatchTaskState.NodePreempted, DeleteBatchJobAndRequeueTaskAsync)
             };
         }
 
@@ -246,7 +246,6 @@ namespace TesApi.Web
             }
         }
 
-        // TODO: Detect batch node preemption and return BatchTaskState.NodePreempted
         /// <summary>
         /// Gets the current state of the Azure Batch task
         /// </summary>
@@ -300,6 +299,11 @@ namespace TesApi.Web
                         if (azureBatchJobAndTaskState.NodeState == ComputeNodeState.Unusable)
                         {
                             return new CombinedBatchTaskInfo { BatchTaskState = BatchTaskState.NodeUnusable, FailureReason = BatchTaskState.NodeUnusable.ToString(), SystemLogItems = ConvertNodeErrorsToSystemLogItems(azureBatchJobAndTaskState) };
+                        }
+
+                        if (azureBatchJobAndTaskState.NodeState == ComputeNodeState.Preempted)
+                        {
+                            return new CombinedBatchTaskInfo { BatchTaskState = BatchTaskState.NodePreempted, FailureReason = BatchTaskState.NodePreempted.ToString(), SystemLogItems = ConvertNodeErrorsToSystemLogItems(azureBatchJobAndTaskState) };
                         }
 
                         if (azureBatchJobAndTaskState.NodeErrorCode != null)

--- a/src/TesApi.Web/CachingWithRetriesAzureProxy.cs
+++ b/src/TesApi.Web/CachingWithRetriesAzureProxy.cs
@@ -136,6 +136,9 @@ namespace TesApi.Web
         public Task<IEnumerable<string>> ListOldJobsToDeleteAsync(TimeSpan oldestJobAge) => asyncRetryPolicy.ExecuteAsync(() => azureProxy.ListOldJobsToDeleteAsync(oldestJobAge));
 
         /// <inheritdoc/>
+        public Task<IEnumerable<string>> ListOrphanedJobsToDeleteAsync(TimeSpan minJobAge) => asyncRetryPolicy.ExecuteAsync(() => azureProxy.ListOrphanedJobsToDeleteAsync(minJobAge));
+
+        /// <inheritdoc/>
         public Task UploadBlobAsync(Uri blobAbsoluteUri, string content) => asyncRetryPolicy.ExecuteAsync(() => azureProxy.UploadBlobAsync(blobAbsoluteUri, content));
 
         /// <inheritdoc/>

--- a/src/TesApi.Web/DeleteOrphanedBatchJobsHostedService.cs
+++ b/src/TesApi.Web/DeleteOrphanedBatchJobsHostedService.cs
@@ -13,7 +13,7 @@ namespace TesApi.Web
     /// </summary>
     public class DeleteOrphanedBatchJobsHostedService : BackgroundService
     {
-        private static readonly TimeSpan runInterval = TimeSpan.FromHours(4);
+        private static readonly TimeSpan runInterval = TimeSpan.FromHours(1);
         private static readonly TimeSpan minJobAge = TimeSpan.FromHours(1);
 
         private readonly IRepository<TesTask> repository;

--- a/src/TesApi.Web/DeleteOrphanedBatchJobsHostedService.cs
+++ b/src/TesApi.Web/DeleteOrphanedBatchJobsHostedService.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Tes.Models;
+using Tes.Repository;
+
+namespace TesApi.Web
+{
+    /// <summary>
+    /// Background service to delete active Batch jobs that have no tasks as the result of job creation exception.
+    /// </summary>
+    public class DeleteOrphanedBatchJobsHostedService : BackgroundService
+    {
+        private static readonly TimeSpan runInterval = TimeSpan.FromHours(4);
+        private static readonly TimeSpan minJobAge = TimeSpan.FromHours(1);
+
+        private readonly IRepository<TesTask> repository;
+        private readonly IAzureProxy azureProxy;
+        private readonly ILogger<DeleteOrphanedBatchJobsHostedService> logger;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="azureProxy">Azure Proxy</param>
+        /// <param name="repository">The main TES task database repository</param>
+        /// <param name="logger">The logger instance</param>
+        public DeleteOrphanedBatchJobsHostedService(IAzureProxy azureProxy, IRepository<TesTask> repository, ILogger<DeleteOrphanedBatchJobsHostedService> logger)
+        {
+            this.repository = repository;
+            this.azureProxy = azureProxy;
+            this.logger = logger;
+        }
+
+        /// <inheritdoc />
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Orphaned job cleanup service started");
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await DeleteOrphanedJobsAsync(cancellationToken);
+                }
+                catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
+                {
+                    logger.LogError(ex, ex.Message);
+                }
+
+                await Task.Delay(runInterval, cancellationToken);
+            }
+        }
+
+        private async Task DeleteOrphanedJobsAsync(CancellationToken cancellationToken)
+        {
+            var jobsToDelete = await azureProxy.ListOrphanedJobsToDeleteAsync(minJobAge);
+
+            foreach (var jobId in jobsToDelete)
+            {
+                var tesTaskId = jobId.Split(new[] { '-' })[0];
+
+                TesTask tesTask = null;
+
+                if (await repository.TryGetItemAsync(tesTaskId, item => tesTask = item))
+                {
+                    if (tesTask.State == TesState.COMPLETEEnum ||
+                        tesTask.State == TesState.EXECUTORERROREnum ||
+                        tesTask.State == TesState.SYSTEMERROREnum ||
+                        tesTask.State == TesState.CANCELEDEnum ||
+                        tesTask.State == TesState.UNKNOWNEnum)
+                    {
+                        await azureProxy.DeleteBatchJobAsync(tesTaskId);
+                        logger.LogInformation($"Deleted orphaned Batch Job '{jobId}'");
+                    }
+                    else
+                    {
+                        logger.LogWarning($"Not deleting orphaned Batch Job '{jobId}' because the corresponding TES task '{tesTaskId}' is in '{tesTask.State}' state.");
+                    }
+                }
+                else
+                {
+                    logger.LogError($"Not deleting orphaned Batch Job '{jobId}' because the corresponding TES task '{tesTaskId}' was not found. Investigate and delete the job manually.");
+                }
+            }
+        }
+    }
+}

--- a/src/TesApi.Web/IAzureProxy.cs
+++ b/src/TesApi.Web/IAzureProxy.cs
@@ -138,6 +138,12 @@ namespace TesApi.Web
         Task<IEnumerable<string>> ListOldJobsToDeleteAsync(TimeSpan oldestJobAge);
 
         /// <summary>
+        /// Gets the ids of orphaned Batch jobs older than specified timespan
+        /// </summary>
+        /// <returns>List of Batch job ids</returns>
+        Task<IEnumerable<string>> ListOrphanedJobsToDeleteAsync(TimeSpan minJobAge);
+
+        /// <summary>
         /// Gets the list of active pool ids matching the prefix and with creation time older than the minAge
         /// </summary>
         /// <returns>Active pool ids</returns>

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -106,6 +106,7 @@ namespace TesApi.Web
 
             services.AddHostedService<Scheduler>();
             services.AddHostedService<DeleteCompletedBatchJobsHostedService>();
+            services.AddHostedService<DeleteOrphanedBatchJobsHostedService>();
             services.AddHostedService<DeleteOrphanedAutoPoolsHostedService>();
             services.AddHostedService<RefreshVMSizesAndPricesHostedService>();
 

--- a/src/TesApi.Web/TesApi.Web.csproj
+++ b/src/TesApi.Web/TesApi.Web.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.14" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.2" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageReference Include="YamlDotNet" Version="11.1.1" />
   </ItemGroup>


### PR DESCRIPTION
Added background service to clean up the "orphaned" Batch jobs, leftover after an exception during creation. 
Handling preempted Batch nodes.
Closes #267