### PR TITLE
Added VmOs Provider and Name to allow using ubuntu 20.04

### DIFF
--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -211,6 +211,8 @@ Configuration   parameter | Has default | Validated | Used by update | Comment
 string   SubscriptionId | N | Y | Y | Azure Subscription Id - Always required
 string   RegionName | N | Y | N | Azure region name to deploy to - Required for new install
 string   MainIdentifierPrefix = "coa" | Y | Y | N | Prefix for all resources to be deployed - Required to deploy but defaults to "coa"
+string   VmOsProvider = "Canonical" | Y | N | N | OS Provider VM to use as the host - Not required and defaults to Ubuntu
+string   VmOsName = "UbuntuServer" | Y | N | N | OS Name of the VM to use as the host - Not required and defaults to UbuntuServer
 string   VmOsVersion = "18.04-LTS" | Y | N | N | OS Version of the Linux Ubuntu VM to use as the host - Not required and defaults to Ubuntu 18.04 LTS
 string   VmSize   = "Standard_D3_v2" | Y | N | N | VM size of the Linux Ubuntu VM to use as the host - Not required and defaults to [Standard_D3_v2](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv2-series)
 string   VmUsername = "vmadmin"; | Y | N | Y | Username created on Cromwell on Azure Linux host - Not required and defaults to "vmadmin"

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -14,6 +14,8 @@ namespace CromwellOnAzureDeployer
         public string SubscriptionId { get; set; }
         public string RegionName { get; set; }
         public string MainIdentifierPrefix { get; set; } = "coa";
+        public string VmOsProvider { get; set; } = "Canonical";
+        public string VmOsName { get; set; } = "UbuntuServer";
         public string VmOsVersion { get; set; } = "18.04-LTS";
         public string VmSize { get; set; } = "Standard_D3_v2";
         public string VnetAddressSpace { get; set; } = "10.0.0.0/24";

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1003,7 +1003,7 @@ namespace CromwellOnAzureDeployer
                 .WithPrimaryPrivateIPAddressDynamic();
 
             var vmDefinitionPart2 = (configuration.PrivateNetworking.GetValueOrDefault() ? vmDefinitionPart1.WithoutPrimaryPublicIPAddress() : vmDefinitionPart1.WithNewPrimaryPublicIPAddress(configuration.VmName))
-                .WithLatestLinuxImage("Canonical", "UbuntuServer", configuration.VmOsVersion)
+                .WithLatestLinuxImage(configuration.VmOsProvider, configuration.VmOsName, configuration.VmOsVersion)
                 .WithRootUsername(configuration.VmUsername)
                 .WithRootPassword(configuration.VmPassword)
                 .WithNewDataDisk(dataDiskSizeGiB, dataDiskLun, CachingTypes.None)


### PR DESCRIPTION
Adder `VmOsProvider` and `VmOsName` to allow full name of an image.

This is to add the ability to run ubuntu 20.04 which is not called `ubuntu:server:18.04-lts` but `Canonical:0001-com-ubuntu-server-focal:20_04-lts`