### PR TITLE
Adding ability to record task warnings and expose them in the trigger file

### DIFF
--- a/src/Common/FailedTaskInfo.cs
+++ b/src/Common/FailedTaskInfo.cs
@@ -8,6 +8,7 @@ namespace Common
     public class FailedTaskInfo
     {
         public string TaskId { get; set; }
+        public string TaskName { get; set; }
         public string FailureReason { get; set; }
         public List<string> SystemLogs { get; set; }
         public string StdOut { get; set; }

--- a/src/Common/TaskWarning.cs
+++ b/src/Common/TaskWarning.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Common
+{
+    public class TaskWarning
+    {
+        public string TaskId { get; set; }
+        public string TaskName { get; set; }
+        public string Warning { get; set; }
+        public List<string> WarningDetails { get; set; }
+
+        public bool ShouldSerializeWarningDetails() => WarningDetails?.Count > 0;
+    }
+}

--- a/src/Common/Workflow.cs
+++ b/src/Common/Workflow.cs
@@ -13,7 +13,9 @@ namespace Common
         public string WorkflowOptionsUrl { get; set; }
         public string WorkflowDependenciesUrl { get; set; }
         public WorkflowFailureInfo WorkflowFailureInfo { get; set; }
+        public List<TaskWarning> TaskWarnings { get; set; }
 
         public bool ShouldSerializeWorkflowFailureInfo() => WorkflowFailureInfo is object;
+        public bool ShouldSerializeTaskWarnings() => TaskWarnings?.Count > 0;
     }
 }

--- a/src/Tes/Extensions/TesTaskExtensions.cs
+++ b/src/Tes/Extensions/TesTaskExtensions.cs
@@ -51,6 +51,19 @@ namespace Tes.Extensions
         }
 
         /// <summary>
+        /// Sets the warning for <see cref="TesTask"/> and optionally adds additional system log items
+        /// </summary>
+        /// <param name="tesTask"><see cref="TesTask"/></param>
+        /// <param name="warning">Warning code</param>
+        /// <param name="additionalSystemLogItems">Additional system log entries</param>
+        public static void SetWarning(this TesTask tesTask, string warning, params string[] additionalSystemLogItems)
+        {
+            tesTask.GetOrAddTesTaskLog().Warning = warning;
+            tesTask.AddToSystemLog(new[] { warning });
+            tesTask.AddToSystemLog(additionalSystemLogItems.Where(i => !string.IsNullOrEmpty(i)));
+        }
+
+        /// <summary>
         /// Returns the last <see cref="TesTaskLog"/>. Adds it if none exist.
         /// </summary>
         /// <param name="tesTask"><see cref="TesTask"/></param>

--- a/src/Tes/Models/TesTaskExtended.cs
+++ b/src/Tes/Models/TesTaskExtended.cs
@@ -47,6 +47,12 @@ namespace Tes.Models
         public string FailureReason => this.Logs?.LastOrDefault()?.FailureReason;
 
         /// <summary>
+        /// Warning that gets populated if task encounters an issue that needs user's attention.
+        /// </summary>
+        [IgnoreDataMember]
+        public string Warning => this.Logs?.LastOrDefault()?.Warning;
+
+        /// <summary>
         /// Cromwell-specific result code, populated when Batch task execution ends in COMPLETED, containing the exit code of the inner Cromwell script.
         /// </summary>
         [IgnoreDataMember]

--- a/src/Tes/Models/TesTaskLogExtended.cs
+++ b/src/Tes/Models/TesTaskLogExtended.cs
@@ -46,6 +46,13 @@ namespace Tes.Models
         public string FailureReason { get; set; }
 
         /// <summary>
+        /// Warning that gets populated if task encounters an issue that needs user's attention.
+        /// </summary>
+        [JsonIgnore]
+        [TesTaskLogMetadataKey("warning")]
+        public string Warning { get; set; }
+
+        /// <summary>
         /// Cromwell-specific result code, populated when Batch task execution ends in COMPLETED, containing the exit code of the inner Cromwell script.
         /// </summary>
         [JsonIgnore]


### PR DESCRIPTION
Adding ability to record task warnings and expose them in the trigger file for both successful and failed workflows. This will be initially used to inform the user about Batch quotas that need to be increased. Related to #207 