### PR TITLE
Added support creating batch nodes on the private subnet

### DIFF
--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -32,15 +32,17 @@ namespace TesApi.Web
         private const string BatchScriptFileName = "batch_script";
         private const string UploadFilesScriptFileName = "upload_files_script";
         private const string DownloadFilesScriptFileName = "download_files_script";
-        private const string DockerInDockerImageName = "docker";
-        private const string BlobxferImageName = "mcr.microsoft.com/blobxfer";
         private static readonly Regex queryStringRegex = new Regex(@"[^\?.]*(\?.*)");
+        private readonly string dockerInDockerImageName;
+        private readonly string blobxferImageName;
         private readonly ILogger logger;
         private readonly IAzureProxy azureProxy;
         private readonly IStorageAccessProvider storageAccessProvider;
         private readonly IEnumerable<string> allowedVmSizes;
         private readonly List<TesTaskStateTransition> tesTaskStateTransitions;
         private readonly bool usePreemptibleVmsOnly;
+        private readonly string batchNodesSubnetId;
+        private readonly bool disableBatchNodesPublicIpAddress;
 
         /// <summary>
         /// Orchestrates <see cref="TesTask"/>s on Azure Batch
@@ -57,6 +59,10 @@ namespace TesApi.Web
 
             this.allowedVmSizes = configuration.GetValue<string>("AllowedVmSizes", null)?.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
             this.usePreemptibleVmsOnly = configuration.GetValue("UsePreemptibleVmsOnly", false);
+            this.batchNodesSubnetId = configuration.GetValue("BatchNodesSubnetId", string.Empty);
+            this.dockerInDockerImageName = configuration.GetValue("DockerInDockerImageName", "docker");
+            this.blobxferImageName = configuration.GetValue("BlobxferImageName", "mcr.microsoft.com/blobxfer");
+            this.disableBatchNodesPublicIpAddress = configuration.GetValue("DisableBatchNodesPublicIpAddress", false);
 
             logger.LogInformation($"usePreemptibleVmsOnly: {usePreemptibleVmsOnly}");
 
@@ -237,6 +243,12 @@ namespace TesApi.Web
                 tesTask.State = TesState.SYSTEMERROREnum;
                 tesTask.SetFailureReason(exc);
                 logger.LogError(exc, exc.Message);
+            }
+            catch (BatchClientException exc)
+            {
+                tesTask.State = TesState.SYSTEMERROREnum;
+                tesTask.SetFailureReason("BatchClientException", string.Join(",", exc.Data.Values), exc.Message, exc.StackTrace);
+                logger.LogError(exc, exc.Message + ", " + string.Join(",", exc.Data.Values));
             }
             catch (Exception exc)
             {
@@ -504,16 +516,26 @@ namespace TesApi.Web
             var volumeMountsOption = $"-v /mnt{cromwellPathPrefixWithoutEndSlash}:{cromwellPathPrefixWithoutEndSlash}";
 
             var executorImageIsPublic = (await azureProxy.GetContainerRegistryInfoAsync(executor.Image)) == null;
+            var dockerInDockerImageIsPublic = (await azureProxy.GetContainerRegistryInfoAsync(dockerInDockerImageName)) == null;
+            var blobXferImageIsPublic = (await azureProxy.GetContainerRegistryInfoAsync(blobxferImageName)) == null;
 
             var sb = new StringBuilder();
 
             sb.AppendLine($"write_kv() {{ echo \"$1=$2\" >> /mnt{metricsPath}; }} && \\");  // Function that appends key=value pair to metrics.txt file
             sb.AppendLine($"write_ts() {{ write_kv $1 $(date -Iseconds); }} && \\");    // Function that appends key=<current datetime> to metrics.txt file
             sb.AppendLine($"mkdir -p /mnt{batchExecutionDirectoryPath} && \\");
-            sb.AppendLine($"(grep -q alpine /etc/os-release && apk add bash || :) && \\");  // Install bash if running on alpine (will be the case if running inside "docker" image)
-            sb.AppendLine($"write_ts BlobXferPullStart && \\");
-            sb.AppendLine($"docker pull --quiet {BlobxferImageName} && \\");
-            sb.AppendLine($"write_ts BlobXferPullEnd && \\");
+
+            if (dockerInDockerImageIsPublic)
+            {
+                sb.AppendLine($"(grep -q alpine /etc/os-release && apk add bash || :) && \\");  // Install bash if running on alpine (will be the case if running inside "docker" image)
+            }
+
+            if (blobXferImageIsPublic)
+            {
+                sb.AppendLine($"write_ts BlobXferPullStart && \\");
+                sb.AppendLine($"docker pull --quiet {blobxferImageName} && \\");
+                sb.AppendLine($"write_ts BlobXferPullEnd && \\");
+            }
 
             if (executorImageIsPublic)
             {
@@ -525,18 +547,18 @@ namespace TesApi.Web
             // After task completion, metrics file is downloaded and used to populate the BatchNodeMetrics object
             sb.AppendLine($"write_kv ExecutorImageSizeInBytes $(docker inspect {executor.Image} | grep \\\"Size\\\" | grep - Po '(?i)\\\"Size\\\":\\K([^,]*)') && \\");
             sb.AppendLine($"write_ts DownloadStart && \\");
-            sb.AppendLine($"docker run --rm {volumeMountsOption} --entrypoint=/bin/sh {BlobxferImageName} {downloadFilesScriptPath} && \\");
+            sb.AppendLine($"docker run --rm {volumeMountsOption} --entrypoint=/bin/sh {blobxferImageName} {downloadFilesScriptPath} && \\");
             sb.AppendLine($"write_ts DownloadEnd && \\");
             sb.AppendLine($"chmod -R o+rwx /mnt{cromwellPathPrefixWithoutEndSlash} && \\");
             sb.AppendLine($"write_ts ExecutorStart && \\");
             sb.AppendLine($"docker run --rm {volumeMountsOption} --entrypoint= --workdir / {executor.Image} {executor.Command[0]} -c \"{ string.Join(" && ", executor.Command.Skip(1))}\" && \\");
             sb.AppendLine($"write_ts ExecutorEnd && \\");
             sb.AppendLine($"write_ts UploadStart && \\");
-            sb.AppendLine($"docker run --rm {volumeMountsOption} --entrypoint=/bin/sh {BlobxferImageName} {uploadFilesScriptPath} && \\");
+            sb.AppendLine($"docker run --rm {volumeMountsOption} --entrypoint=/bin/sh {blobxferImageName} {uploadFilesScriptPath} && \\");
             sb.AppendLine($"write_ts UploadEnd && \\");
             sb.AppendLine($"/bin/bash -c 'disk=( `df -k /mnt | tail -1` ) && echo DiskSizeInKiB=${{disk[1]}} >> /mnt{metricsPath} && echo DiskUsedInKiB=${{disk[2]}} >> /mnt{metricsPath}' && \\");
             sb.AppendLine($"write_kv VmCpuModelName \"$(cat /proc/cpuinfo | grep -m1 name | cut -f 2 -d ':' | xargs)\" && \\");
-            sb.AppendLine($"docker run --rm {volumeMountsOption} {BlobxferImageName} upload --storage-url \"{metricsUrl}\" --local-path \"{metricsPath}\" --rename --no-recursive");
+            sb.AppendLine($"docker run --rm {volumeMountsOption} {blobxferImageName} upload --storage-url \"{metricsUrl}\" --local-path \"{metricsPath}\" --rename --no-recursive");
 
             var batchScriptPath = $"{batchExecutionDirectoryPath}/{BatchScriptFileName}";
             await this.storageAccessProvider.UploadBlobAsync(batchScriptPath, sb.ToString());
@@ -563,7 +585,7 @@ namespace TesApi.Web
                 // If the executor image is public, there is no need for pool ContainerConfiguration and task can run normally, without being wrapped in a docker container.
                 // Volume mapping for docker.sock below allows the docker client in the container to access host's docker daemon.
                 var containerRunOptions = $"--rm -v /var/run/docker.sock:/var/run/docker.sock -v /mnt:/mnt ";
-                cloudTask.ContainerSettings = new TaskContainerSettings(DockerInDockerImageName, containerRunOptions);
+                cloudTask.ContainerSettings = new TaskContainerSettings(dockerInDockerImageName, containerRunOptions);
             }
 
             return cloudTask;
@@ -644,17 +666,17 @@ namespace TesApi.Web
         /// <summary>
         /// Constructs an Azure Batch PoolInformation instance
         /// </summary>
-        /// <param name="image">The image name for the current <see cref="TesTask"/></param>
+        /// <param name="executorImage">The image name for the current <see cref="TesTask"/></param>
         /// <param name="vmSize">The Azure VM sku</param>
         /// <param name="preemptible">True if preemptible machine should be used</param>
         /// <returns></returns>
-        private async Task<PoolInformation> CreatePoolInformation(string image, string vmSize, bool preemptible)
+        private async Task<PoolInformation> CreatePoolInformation(string executorImage, string vmSize, bool preemptible)
         {
             var vmConfig = new VirtualMachineConfiguration(
                 imageReference: new ImageReference("ubuntu-server-container", "microsoft-azure-batch", "16-04-lts", "latest"),
                 nodeAgentSkuId: "batch.node.ubuntu 16.04");
 
-            var containerRegistryInfo = await azureProxy.GetContainerRegistryInfoAsync(image);
+            var containerRegistryInfo = await azureProxy.GetContainerRegistryInfoAsync(executorImage);
 
             if (containerRegistryInfo != null)
             {
@@ -667,9 +689,33 @@ namespace TesApi.Web
                 // Doing this also requires that the main task runs inside a container, hence downloading the "docker" image (contains docker client) as well.
                 vmConfig.ContainerConfiguration = new ContainerConfiguration
                 {
-                    ContainerImageNames = new List<string> { image, DockerInDockerImageName },
+                    ContainerImageNames = new List<string> { executorImage, dockerInDockerImageName, blobxferImageName },
                     ContainerRegistries = new List<ContainerRegistry> { containerRegistry }
                 };
+
+                var containerRegistryInfoForDockerInDocker = await azureProxy.GetContainerRegistryInfoAsync(dockerInDockerImageName);
+
+                if(containerRegistryInfoForDockerInDocker != null && containerRegistryInfoForDockerInDocker.RegistryServer != containerRegistryInfo.RegistryServer)
+                {
+                    var containerRegistryForDockerInDocker = new ContainerRegistry(
+                        userName: containerRegistryInfoForDockerInDocker.Username,
+                        registryServer: containerRegistryInfoForDockerInDocker.RegistryServer,
+                        password: containerRegistryInfoForDockerInDocker.Password);
+
+                    vmConfig.ContainerConfiguration.ContainerRegistries.Add(containerRegistryForDockerInDocker);
+                }
+
+                var containerRegistryInfoForBlobXfer = await azureProxy.GetContainerRegistryInfoAsync(blobxferImageName);
+
+                if (containerRegistryInfoForBlobXfer != null && containerRegistryInfoForBlobXfer.RegistryServer != containerRegistryInfo.RegistryServer && containerRegistryInfoForBlobXfer.RegistryServer != containerRegistryInfoForDockerInDocker.RegistryServer)
+                {
+                    var containerRegistryForBlobXfer = new ContainerRegistry(
+                        userName: containerRegistryInfoForBlobXfer.Username,
+                        registryServer: containerRegistryInfoForBlobXfer.RegistryServer,
+                        password: containerRegistryInfoForBlobXfer.Password);
+
+                    vmConfig.ContainerConfiguration.ContainerRegistries.Add(containerRegistryForBlobXfer);
+                }
             }
 
             var poolSpecification = new PoolSpecification
@@ -680,6 +726,15 @@ namespace TesApi.Web
                 TargetLowPriorityComputeNodes = preemptible ? 1 : 0,
                 TargetDedicatedComputeNodes = preemptible ? 0 : 1
             };
+
+            if (!string.IsNullOrEmpty(this.batchNodesSubnetId))
+            {
+                poolSpecification.NetworkConfiguration = new NetworkConfiguration
+                {
+                    PublicIPAddressConfiguration = new PublicIPAddressConfiguration(this.disableBatchNodesPublicIpAddress ? IPAddressProvisioningType.NoPublicIPAddresses : IPAddressProvisioningType.BatchManaged),
+                    SubnetId = this.batchNodesSubnetId
+                };
+            }
 
             var poolInformation = new PoolInformation
             {

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -41,6 +41,10 @@ namespace CromwellOnAzureDeployer
         public string SubnetName { get; set; }
         public bool? PrivateNetworking { get; set; } = null;
         public string Tags { get; set; } = null;
+        public string BatchNodesSubnetId { get; set; } = null;
+        public string DockerInDockerImageName { get; set; } = null;
+        public string BlobxferImageName { get; set; } = null;
+        public bool? DisableBatchNodesPublicIpAddress{ get; set; } = null;
 
         public static Configuration BuildConfiguration(string[] args)
         {

--- a/src/deploy-cromwell-on-azure/scripts/docker-compose.yml
+++ b/src/deploy-cromwell-on-azure/scripts/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - TesImageSha=$TesImageSha
       - TriggerServiceImageSha=$TriggerServiceImageSha
       - DisableBatchScheduling=$DisableBatchScheduling
+      - BatchNodesSubnetId=$BatchNodesSubnetId
+      - DockerInDockerImageName=$DockerInDockerImageName
+      - BlobxferImageName=$BlobxferImageName
+      - DisableBatchNodesPublicIpAddress=$DisableBatchNodesPublicIpAddress
     expose:
       - "80"
     volumes:


### PR DESCRIPTION
Added support creating batch nodes on the private subnet, and optionally disabling nodes' public IP.  Customer is responsible for creating and configuring the subnet, creating the ACR and copying executor, docker and blobxfer images to it and enabling access to ACR/storage from the subnet, as well as making sure no resources are accessible from the internet. More docs on this to follow.

New deployer command line options (can be used during initial installation or update):
- --BatchNodesSubnetId, for example: "/subscriptions/<your_subscription_id>/resourceGroups/<your_resource_group>/providers/Microsoft.Network/virtualNetworks/<your_vnet_name>/subnets/<your_subnet_name>"
- --DisableBatchNodesPublicIpAddress _true_ | _false_. If _true_ the nodes will not have access to internet. In that case the next two properties need to be suplied as well.
- --DockerInDockerImageName for example: "<your ACR repository>.azurecr.io/docker". The ACR repository needs to be accessible from the subnet, and the image must be built using the following Dockerfile:
```
FROM docker
RUN apk add bash
```
- --BlobxferImageName, for example: "<your ACR repository>.azurecr.io/blobxfer". The ACR repository needs to be accessible from the subnet. This needs to be a copy of mcr.microsoft.com/blobxfer. For easy import into ACR see https://docs.microsoft.com/en-us/azure/container-registry/container-registry-import-images?tabs=azure-cli

To revert to batch nodes subnet or docker images to defaults, pass an empty string during update. For DisableBatchNodesPublicIpAddress pass _false_.

Use the above with these installation only options that place the host VM into existing subnet and control whether it has a public IP. Unlike the above options, these cannot be changed using the CoA deployer after installation.
- --VnetResourceGroupName e.g. "myResourceGroup"
- --VnetName e.g. "myVnet"
- --SubnetName e.g. "subnet1"
- --PrivateNetworking _true_ | _false_