### PR TITLE
Validate managed identity during upgrades addresses #306

### DIFF
--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -1,13 +1,16 @@
-﻿namespace Common
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Common
 {
     public static class Constants
     {
         public const string CromwellSystemName = "Cromwell";
 
-        public static string CosmosDbDatabaseId = "TES";
+        public const string CosmosDbDatabaseId = "TES";
 
-        public static string CosmosDbContainerId = "Tasks";
+        public const string CosmosDbContainerId = "Tasks";
 
-        public static string CosmosDbPartitionId = "01";
+        public const string CosmosDbPartitionId = "01";
     }
 }


### PR DESCRIPTION
The changes related to #306 are in `deploy-cromwell-on-azure/Deployer.cs` from lines 191-234. The rest is a combination of code modernization I had already started and fixing a bug I noticed in both `GetExistingStorageAccountAsync()` and `GetExistingBatchAccountAsync()`.

Also addresses #304 