### PR TITLE
Use storage v2 accounts and update blobfuse to 1.4.1

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -294,6 +294,14 @@ namespace CromwellOnAzureDeployer
                         {
                             await MitigateChaosDbV250Async(cosmosDb);
                         }
+
+                        if (installedVersion == null || installedVersion < new Version(2, 6))
+                        {
+                            await UpgradeBlobfuseTo141V300Async(sshConnectionInfo);
+                            RefreshableConsole.WriteLine($"It's recommended to update the default CoA storage account to a General Purpose v2 account.");
+                            RefreshableConsole.WriteLine($"To do that, navigate to the storage account in the Azure Portal,");
+                            RefreshableConsole.WriteLine($"Configuration tab, and click 'Upgrade.'");
+                        }
                     }
 
                     if (!configuration.Update)
@@ -1317,6 +1325,11 @@ namespace CromwellOnAzureDeployer
         private async Task MitigateChaosDbV250Async(ICosmosDBAccount cosmosDb)
             => await Execute("#ChaosDB remedition (regenerating CosmosDB primary key)",
                 () => cosmosDb.RegenerateKeyAsync(KeyKind.Primary.Value));
+
+
+        private async Task UpgradeBlobfuseTo141V300Async(ConnectionInfo sshConnectionInfo)
+            => await Execute("Upgrading blobfuse to 1.4.1...",
+                () => ExecuteCommandOnVirtualMachineWithRetriesAsync(sshConnectionInfo, "sudo apt-get update ; sudo apt-get --only-upgrade install blobfuse=1.4.1 ; sudo apt-get install blobfuse=1.4.1"));
 
         private async Task SetCosmosDbContainerAutoScaleAsync(ICosmosDBAccount cosmosDb)
         {

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1329,7 +1329,7 @@ namespace CromwellOnAzureDeployer
 
         private async Task UpgradeBlobfuseTo141V300Async(ConnectionInfo sshConnectionInfo)
             => await Execute("Upgrading blobfuse to 1.4.1...",
-                () => ExecuteCommandOnVirtualMachineWithRetriesAsync(sshConnectionInfo, "sudo apt-get update ; sudo apt-get --only-upgrade install blobfuse=1.4.1 ; sudo apt-get install blobfuse=1.4.1"));
+                () => ExecuteCommandOnVirtualMachineWithRetriesAsync(sshConnectionInfo, "sudo apt-get update ; sudo apt-get --only-upgrade install blobfuse=1.4.1"));
 
         private async Task SetCosmosDbContainerAutoScaleAsync(ICosmosDBAccount cosmosDb)
         {

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -929,6 +929,7 @@ namespace CromwellOnAzureDeployer
                     .Define(configuration.StorageAccountName)
                     .WithRegion(configuration.RegionName)
                     .WithExistingResourceGroup(configuration.ResourceGroupName)
+                    .WithGeneralPurposeAccountKindV2()
                     .WithOnlyHttpsTraffic()
                     .CreateAsync(cts.Token));
 

--- a/src/deploy-cromwell-on-azure/scripts/install-cromwellazure.sh
+++ b/src/deploy-cromwell-on-azure/scripts/install-cromwellazure.sh
@@ -56,7 +56,7 @@ ubuntuVersion=$(lsb_release -ar 2>/dev/null | grep -i release | cut -s -f2)
 sudo wget https://packages.microsoft.com/config/ubuntu/$ubuntuVersion/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 sudo apt update
-sudo apt install -y --allow-downgrades blobfuse=1.2.4 fuse
+sudo apt install -y --allow-downgrades blobfuse=1.4.1 fuse
 
 write_log "Installing az cli"
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash


### PR DESCRIPTION
Currently, CoA uses storage accounts "v1" and also an old blobfuse version, which may cause intermittent connection issues.  This PR is to resolve both of these issues.