### PR TITLE
Change metadata extraction to expandSubWorfklows=true

### DIFF
--- a/src/CromwellApiClient/CromwellApiClient.cs
+++ b/src/CromwellApiClient/CromwellApiClient.cs
@@ -46,7 +46,7 @@ namespace CromwellApiClient
 
         public async Task<GetMetadataResponse> GetMetadataAsync(Guid id)
         {
-            return new GetMetadataResponse { Id = id, Json = await GetAsyncWithMediaType($"/{id}/metadata", "application/json") };
+            return new GetMetadataResponse { Id = id, Json = await GetAsyncWithMediaType($"/{id}/metadata?expandSubWorkflows=true", "application/json") };
         }
 
         public async Task<GetStatusResponse> GetStatusAsync(Guid id)


### PR DESCRIPTION
Adds the `"?expandSubWorkflows=true"` argument to the GetMetadataResponse Task. This ensures that metadata is extracted for the root workflow and the sub-workflows created below it. This more detailed output is then placed into `/<Storage account>/outputs/<output filename>.metadata.json`.

This PR doesn't change the metadata extraction for timing diagrams. So the .timing.html files will still only contain the root workflow tasks and no detailed task information about sub-tasks. Sub-tasks should still be shown with their overall start/end time but no details will be available.

Interested users can generate their own timing.html compatible metadata by using the following [jq](https://stedolan.github.io/jq/) command, 
```
jq -c 'reduce (tostream|select(select(.[0][-1]|.=="executionEvents" or .=="jobId" or .=="id" or .=="start" or .=="end" or .=="startTime" or .=="endTime" or .=="description" or .=="attempt" or .=="shardIndex" or .=="executionStatus")| length>1)) as [$p,$v] ( {}; setpath($p;$v)) | del(.workflowProcessingEvents)' "<output filename>.metadata.json" > timing_output.json
```
You can then visualize this timing information by taking a timing.html file and replacing the JSON data, on line 8, `var metadataJson = <json data>;` with the "timing_output.json" JSON data. 

Since this can be a rather large amount of JSON data to copy/paste. You can script this by creating a clean html file (timing_clean.html) where you replace the var metadataJson line with:
```
        var metadataJson = 
        REPLACE_WITH_METADATA_JSON
        ;
```
Then running:
```
cat timing_output.json | jq -c > file.tmp; sed -e "/REPLACE_WITH_METADATA_JSON/r file.tmp" -e "/REPLACE_WITH_METADATA_JSON/d" timing_clean.html > timing_with_expanded_subworkflows.html
```
You can then remove the file.tmp file.

Note that when you open "timing_with_expanded_subworflows.html" in a browser it will look the same as the timing.html file without the additional metadata. You need to click on the subworkflow items to expand them to see all the details for the subtasks.
