### PR TITLE
Force blob overwrite

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1990,7 +1990,7 @@ namespace CromwellOnAzureDeployer
             var container = blobClient.GetBlobContainerClient(containerName);
 
             await container.CreateIfNotExistsAsync();
-            await container.GetBlobClient(blobName).UploadAsync(BinaryData.FromString(content), cts.Token);
+            await container.GetBlobClient(blobName).UploadAsync(BinaryData.FromString(content), true, cts.Token);
         }
 
         private static string GetLinuxParentPath(string path)


### PR DESCRIPTION
It seems the version bump to the package Azure.Storage.Blobs in this PR: https://github.com/microsoft/CromwellOnAzure/pull/335 changed the behavior of the UploadAsync function to throw an exception if the blob already exists breaking many actions in the upgrade process. 

More details in this issue: https://github.com/microsoft/CromwellOnAzure/issues/358
