### PR TITLE
Move enableSsh inside of private networking check

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -166,18 +166,23 @@ namespace CromwellOnAzureDeployer
 
                         networkSecurityGroup = (await azureSubscriptionClient.NetworkSecurityGroups.ListByResourceGroupAsync(configuration.ResourceGroupName)).FirstOrDefault(g => g.NetworkInterfaceIds.Contains(linuxVm.GetPrimaryNetworkInterface().Id));
 
-                        if (!configuration.PrivateNetworking.GetValueOrDefault() && networkSecurityGroup is null)
+                        if (!configuration.PrivateNetworking.GetValueOrDefault())
                         {
-                            if (string.IsNullOrWhiteSpace(configuration.NetworkSecurityGroupName))
+                            if (networkSecurityGroup is null)
                             {
-                                configuration.NetworkSecurityGroupName = SdkContext.RandomResourceName($"{configuration.MainIdentifierPrefix}", 15);
+                                if (string.IsNullOrWhiteSpace(configuration.NetworkSecurityGroupName))
+                                {
+                                    configuration.NetworkSecurityGroupName = SdkContext.RandomResourceName($"{configuration.MainIdentifierPrefix}", 15);
+                                }
+
+                                networkSecurityGroup = await CreateNetworkSecurityGroupAsync(resourceGroup, configuration.NetworkSecurityGroupName);
+                                await AssociateNicWithNetworkSecurityGroupAsync(linuxVm.GetPrimaryNetworkInterface(), networkSecurityGroup);
                             }
 
-                            networkSecurityGroup = await CreateNetworkSecurityGroupAsync(resourceGroup, configuration.NetworkSecurityGroupName);
-                            await AssociateNicWithNetworkSecurityGroupAsync(linuxVm.GetPrimaryNetworkInterface(), networkSecurityGroup);
+                            await EnableSsh(networkSecurityGroup);
                         }
 
-                        await EnableSsh(networkSecurityGroup);
+
 
                         sshConnectionInfo = GetSshConnectionInfo(linuxVm, configuration.VmUsername, configuration.VmPassword);
 


### PR DESCRIPTION
Fixes issue: https://github.com/microsoft/CromwellOnAzure/issues/353 

Moves enableSsh inside of the private networking check, upgrade fails otherwise for private networking because the NSG will be null. 