### PR TITLE
Use User account (not admin account) for managed Azure MySQL

### DIFF
--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -224,6 +224,8 @@ string   VmPassword | Y | N | Y | Required for update
 string   VnetResourceGroupName | Y | Y | N | Available starting version 2.1. The resource group name of the specified virtual network to use - Not required, generated automatically if not provided. If specified, VnetName and SubnetName must be provided.
 string   VnetName | Y | Y | N | Available starting version 2.1. The name of the specified virtual network to use - Not required, generated automatically if not provided. If specified, VnetResourceGroupName and SubnetName must be provided.
 string   SubnetName | Y | Y | N | Available starting version 2.1. The subnet name of the specified virtual network to use - Not required, generated automatically if not provided. If specified, VnetResourceGroupName and VnetName must be provided.
+string   VmSubnetName | Y | Y | N | Available starting version 3.1. The subnet name of the specified virtual network to use for the VM - Not required, generated automatically if not provided and ProvisionMySQLOnAzure is true. If specified, VnetResourceGroupName, VnetName, and MySqlSubnetName  must be provided.
+string   MySqlSubnetName  | Y | Y | N | Available starting version 3.1. The subnet name of the specified virtual network to use for the Azure MySQL database- Not required, generated automatically if not provided and ProvisionMySQLOnAzure is true. If specified, VnetResourceGroupName, VnetName, and VmSubnetName must be provided.
 string   ResourceGroupName | Y | Y | Y | Required for update.   If provided for new Cromwell on Azure deployment, it must already exist.
 string   BatchAccountName | Y | N | N | The name of the Azure Batch Account to use ; must be in the SubscriptionId and RegionName provided - Not required, generated automatically if not provided
 string   StorageAccountName | Y | N | N | The name of the Azure Storage Account to use ; must be in the SubscriptionId provided - Not required, generated automatically if not provided
@@ -237,7 +239,7 @@ bool     Update =   false; | Y | Y | Y | Set to true if you want to update your 
 bool     PrivateNetworking = false; | Y | Y | N | Available starting version 2.2. Set to true to create the host VM without public IP address. If set, VnetResourceGroupName, VnetName and SubnetName must be provided (and already exist). The deployment must be initiated from a machine that has access to that subnet.
 bool     KeepSshPortOpen =   false; | Y | Y | Y | Available starting version 3.0. Set to true if you need to keep the SSH port accessible on the host VM while deployer is not running (not recommended). 
 string   LogAnalyticsArmId | Y | N | N | Arm resource id for an exising Log Analytics workspace, workspace is used for App Insights - Not required, a workspace will be generated automatically if not provided.
-bool     ProvisionMySQLOnAzure =   false; | Y | N | N | Triggers whether to use Docker MySQL or Azure MySQL when provisioning the database.
+bool     ProvisionMySQLOnAzure =   false; | Y | N | N | Available starting version 3.1. Triggers whether to use Docker MySQL or Azure MySQL when provisioning the database.
 
 ### Use a specific Cromwell version
 #### Before deploying Cromwell on Azure

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -12,10 +12,11 @@ namespace CromwellOnAzureDeployer
     public class Configuration : UserAccessibleConfiguration
     {
         public string MySqlServerName { get; set; }
-        public string MySqlServerPassword { get; set; }
         public string MySqlDatabaseName { get; set; } = "cromwell_db";
-        public string MySqlAdministratorLogin { get; set; } = "cromwell";
-        public string MySqlAdministratorLoginPassword { get; set; }
+        public string MySqlAdministratorLogin { get; set; } = "coa_admin";
+        public string MySqlAdministratorPassword { get; set; }
+        public string MySqlUserLogin { get; set; } = "cromwell";
+        public string MySqlUserPassword { get; set; }
         public string MySqlSkuName { get; set; } = "Standard_B1s";
         public string MySqlTier { get; set; } = "Burstable";
         public string DefaultVmSubnetName { get; set; } = "vmsubnet";

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -429,6 +429,7 @@ namespace CromwellOnAzureDeployer
                             Task.Run(async () =>
                             {
                                 storageAccount ??= await CreateStorageAccountAsync();
+
                                 await Task.WhenAll(new Task[]
                                 {
                                     Task.Run(async () => batchAccount ??= await CreateBatchAccountAsync(storageAccount.Id)),
@@ -854,17 +855,17 @@ namespace CromwellOnAzureDeployer
 
                     (Utility.PersonalizeContent(new []
                     {
-                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName ?? String.Empty),
-                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin ?? String.Empty),
-                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword),
                     }, "scripts", "env-13-my-sql-db.txt"),
                     $"{CromwellAzureRootDir}/env-13-my-sql-db.txt", false),
 
                     (Utility.PersonalizeContent(new []
                     {
-                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName ?? String.Empty),
-                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin ?? String.Empty),
-                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword),
                     }, "scripts", "mysql", "init-user.sql"),
                     $"{CromwellAzureRootDir}/mysql-init/init-user.sql", false),
                 });
@@ -1052,9 +1053,9 @@ namespace CromwellOnAzureDeployer
                     await UploadTextToStorageAccountAsync(storageAccount, ConfigurationContainerName, CromwellConfigurationFileName, Utility.PersonalizeContent(new[]
                     {
                         new Utility.ConfigReplaceTextItem("{MySqlServerName}", configuration.ProvisionMySqlOnAzure.GetValueOrDefault() ? $"{configuration.MySqlServerName}.mysql.database.azure.com" : "mysqldb"),
-                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName ?? String.Empty),
-                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin ?? String.Empty),
-                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword),
                         new Utility.ConfigReplaceTextItem("{MySqlUseSSL}", configuration.ProvisionMySqlOnAzure.GetValueOrDefault() ? "true" : "false"),
                     }, "scripts", CromwellConfigurationFileName));
                     await UploadTextToStorageAccountAsync(storageAccount, ConfigurationContainerName, AllowedVmSizesFileName, Utility.GetFileContent("scripts", AllowedVmSizesFileName));

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -267,7 +267,6 @@ namespace CromwellOnAzureDeployer
                         // Note: Current behavior is to block switching from Docker MySQL to Azure MySQL on Update.
                         // However we do ancitipate including this change, this code is here to facilitate this future behavior.
                         configuration.MySqlServerName = accountNames.GetValueOrDefault("MySqlServerName");
-                        //configuration.ProvisionMySqlOnAzure = !string.IsNullOrEmpty(MySqlServerName);
 
                         var installedVersion = await GetInstalledCromwellOnAzureVersionAsync(sshConnectionInfo);
 
@@ -321,7 +320,8 @@ namespace CromwellOnAzureDeployer
 
                         // Configuration preferences not currently settable by user.
                         configuration.MySqlServerName = configuration.ProvisionMySqlOnAzure.GetValueOrDefault() ? SdkContext.RandomResourceName($"{configuration.MainIdentifierPrefix}-", 15) : String.Empty;
-                        configuration.MySqlServerPassword = Utility.GeneratePassword();
+                        configuration.MySqlAdministratorPassword = Utility.GeneratePassword();
+                        configuration.MySqlUserPassword = Utility.GeneratePassword();
 
                         if (string.IsNullOrWhiteSpace(configuration.BatchAccountName))
                         {
@@ -473,7 +473,7 @@ namespace CromwellOnAzureDeployer
 
                         if (configuration.ProvisionMySqlOnAzure.GetValueOrDefault())
                         {
-                            await ExecuteQueriesOnAzureMySqlDb(sshConnectionInfo, mySQLServer);
+                            await CreateMySqlDatabaseUser(sshConnectionInfo, mySQLServer);
                         }
                     }
 
@@ -810,7 +810,6 @@ namespace CromwellOnAzureDeployer
                         ? new[] {
                         (Utility.GetFileContent("scripts", "env-12-local-my-sql-db.txt"), $"{CromwellAzureRootDir}/env-12-local-my-sql-db.txt", false),
                         (Utility.GetFileContent("scripts", "docker-compose.mysql.yml"), $"{CromwellAzureRootDir}/docker-compose.mysql.yml", false),
-                        (Utility.GetFileContent("scripts", "mysql", "init-user.sql"), $"{CromwellAzureRootDir}/mysql-init/init-user.sql", false),
                         (Utility.GetFileContent("scripts", "mysql", "unlock-change-log.sql"), $"{CromwellAzureRootDir}/mysql-init/unlock-change-log.sql", false)
                         }
                         : Array.Empty<(string, string, bool)>())
@@ -829,6 +828,11 @@ namespace CromwellOnAzureDeployer
                 {
                     await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo {CromwellAzureRootDir}/install-cromwellazure.sh");
                     await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo usermod -aG docker {configuration.VmUsername}");
+
+                    if(!string.IsNullOrEmpty(configuration.MySqlServerName))
+                    {
+                        await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo apt install -y mysql-client");
+                    }
                 });
 
         private async Task WritePersonalizedFilesToVmAsync(ConnectionInfo sshConnectionInfo, IIdentity managedIdentity)
@@ -846,11 +850,23 @@ namespace CromwellOnAzureDeployer
                     }, "scripts", "env-01-account-names.txt"),
                     $"{CromwellAzureRootDir}/env-01-account-names.txt", false),
 
+                    (Utility.GetFileContent("scripts", "env-04-settings.txt"), $"{CromwellAzureRootDir}/env-04-settings.txt", false),
+
                     (Utility.PersonalizeContent(new []
                     {
-                        new Utility.ConfigReplaceTextItem("{MySqlServerPassword}", configuration.ProvisionMySqlOnAzure.GetValueOrDefault() ? configuration.MySqlServerPassword : String.Empty),
-                    }, "scripts", "env-04-settings.txt"),
-                    $"{CromwellAzureRootDir}/env-04-settings.txt", false),
+                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword ?? String.Empty),
+                    }, "scripts", "env-13-my-sql-db.txt"),
+                    $"{CromwellAzureRootDir}/env-13-my-sql-db.txt", false),
+
+                    (Utility.PersonalizeContent(new []
+                    {
+                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword ?? String.Empty),
+                    }, "scripts", "mysql", "init-user.sql"),
+                    $"{CromwellAzureRootDir}/mysql-init/init-user.sql", false),
                 });
 
         private async Task HandleCustomImagesAsync(ConnectionInfo sshConnectionInfo)
@@ -1036,7 +1052,9 @@ namespace CromwellOnAzureDeployer
                     await UploadTextToStorageAccountAsync(storageAccount, ConfigurationContainerName, CromwellConfigurationFileName, Utility.PersonalizeContent(new[]
                     {
                         new Utility.ConfigReplaceTextItem("{MySqlServerName}", configuration.ProvisionMySqlOnAzure.GetValueOrDefault() ? $"{configuration.MySqlServerName}.mysql.database.azure.com" : "mysqldb"),
-                        new Utility.ConfigReplaceTextItem("{MySqlServerPassword}", configuration.ProvisionMySqlOnAzure.GetValueOrDefault() ? configuration.MySqlServerPassword : "cromwell"),
+                        new Utility.ConfigReplaceTextItem("{MySqlDatabaseName}", configuration.MySqlDatabaseName ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserLogin}", configuration.MySqlUserLogin ?? String.Empty),
+                        new Utility.ConfigReplaceTextItem("{MySqlUserPassword}", configuration.MySqlUserPassword ?? String.Empty),
                         new Utility.ConfigReplaceTextItem("{MySqlUseSSL}", configuration.ProvisionMySqlOnAzure.GetValueOrDefault() ? "true" : "false"),
                     }, "scripts", CromwellConfigurationFileName));
                     await UploadTextToStorageAccountAsync(storageAccount, ConfigurationContainerName, AllowedVmSizesFileName, Utility.GetFileContent("scripts", AllowedVmSizesFileName));
@@ -1078,17 +1096,16 @@ namespace CromwellOnAzureDeployer
 
         private async Task<Server> CreateMySqlServerAndDatabaseAsync(IMySQLManagementClient mySqlManagementClient, ISubnet subnet)
         {
-            // Confirm subnet has MySQL delegation.
             if (!subnet.Inner.Delegations.Any())
             {
                 subnet.Parent.Update().UpdateSubnet(subnet.Name).WithDelegation("Microsoft.DBforMySQL/flexibleServers");
                 await subnet.Parent.Update().ApplyAsync();
             }
 
-            // Create Server.
             Server server = null;
+
             await Execute(
-                $"Creating MySQL On Azure Server Instance: {configuration.MySqlServerName} With Password: {configuration.MySqlServerPassword}...",
+                $"Creating Azure Database for MySQL: {configuration.MySqlServerName} ...",
                 async () =>
                 {
                     server = await mySqlManagementClient.Servers.CreateAsync(
@@ -1097,18 +1114,17 @@ namespace CromwellOnAzureDeployer
                            location: configuration.RegionName,
                            version: configuration.MySqlVersion,
                            sku: new Sku(configuration.MySqlSkuName, configuration.MySqlTier),
-                           administratorLogin: "cromwell",
-                           administratorLoginPassword: configuration.MySqlServerPassword,
+                           administratorLogin: configuration.MySqlAdministratorLogin,
+                           administratorLoginPassword: configuration.MySqlAdministratorPassword,
                            network: new Network(publicNetworkAccess: "Disabled", delegatedSubnetResourceId: subnet.Inner.Id)
                         ));
                 });
 
-            // Create Database.
             await Execute(
-                $"Creating MySQL On Azure Server Database: cromwell_db...",
+                $"Creating MySQL database: {configuration.MySqlDatabaseName}...",
                 () => mySqlManagementClient.Databases.CreateOrUpdateAsync(
-               configuration.ResourceGroupName, configuration.MySqlServerName, configuration.MySqlDatabaseName,
-               new Database()));
+                    configuration.ResourceGroupName, configuration.MySqlServerName, configuration.MySqlDatabaseName,
+                    new Database()));
  
             return server;
         }
@@ -1255,17 +1271,11 @@ namespace CromwellOnAzureDeployer
                 () => networkInterface.Update().WithExistingNetworkSecurityGroup(networkSecurityGroup).ApplyAsync()
             );
 
-        private Task ExecuteQueriesOnAzureMySqlDb(ConnectionInfo sshConnectionInfo, Server mySQLServer)
-        => Execute(
-            $"Executing scripts on cromwell_db.",
-            async () => {
-                await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo apt install -y mysql-client");
-                var initScript = Utility.PersonalizeContent(new[]
-                {
-                    new Utility.ConfigReplaceRegExItemText("^CREATE USER 'cromwell'@'%'.*$", String.Empty, RegexOptions.Multiline),
-                }, "scripts", "mysql", "init-user.sql");
-                return await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"mysql -u cromwell -p'{configuration.MySqlServerPassword}' -h {mySQLServer.FullyQualifiedDomainName} -P 3306 -D cromwell_db -e \"{initScript}\"");
-            });
+        private Task CreateMySqlDatabaseUser(ConnectionInfo sshConnectionInfo, Server mySqlServer)
+            => Execute(
+                $"Creating MySQL database user...",
+                () => ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"mysql -u {configuration.MySqlAdministratorLogin} -p'{configuration.MySqlAdministratorPassword}' -h {mySqlServer.FullyQualifiedDomainName} -P 3306 < {CromwellAzureRootDir}/mysql-init/init-user.sql")
+            );
 
         private Task<IGenericResource> CreateLogAnalyticsWorkspaceResourceAsync(string workspaceName)
             => Execute(

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -829,7 +829,7 @@ namespace CromwellOnAzureDeployer
                     await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo {CromwellAzureRootDir}/install-cromwellazure.sh");
                     await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo usermod -aG docker {configuration.VmUsername}");
 
-                    if(!string.IsNullOrEmpty(configuration.MySqlServerName))
+                    if(configuration.ProvisionMySqlOnAzure.GetValueOrDefault())
                     {
                         await ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"sudo apt install -y mysql-client");
                     }

--- a/src/deploy-cromwell-on-azure/deploy-cromwell-on-azure.csproj
+++ b/src/deploy-cromwell-on-azure/deploy-cromwell-on-azure.csproj
@@ -67,6 +67,7 @@
     <EmbeddedResource Include="scripts\env-03-external-images.txt" />
     <EmbeddedResource Include="scripts\env-04-settings.txt" />
     <EmbeddedResource Include="scripts\env-12-local-my-sql-db.txt" />
+    <EmbeddedResource Include="scripts\env-13-my-sql-db.txt" />
     <EmbeddedResource Include="scripts\install-cromwellazure.sh" />
     <EmbeddedResource Include="scripts\mount-data-disk.sh" />
     <EmbeddedResource Include="scripts\mount.blobfuse" />

--- a/src/deploy-cromwell-on-azure/scripts/cromwell-application.conf
+++ b/src/deploy-cromwell-on-azure/scripts/cromwell-application.conf
@@ -55,9 +55,9 @@ backend {
 }
 
 database {
-  db.url = "jdbc:mysql://{MySqlServerName}/cromwell_db?useSSL={MySqlUseSSL}&rewriteBatchedStatements=true&allowPublicKeyRetrieval=true"
-  db.user = "cromwell"
-  db.password = "{MySqlServerPassword}"
+  db.url = "jdbc:mysql://{MySqlServerName}/{MySqlDatabaseName}?useSSL={MySqlUseSSL}&rewriteBatchedStatements=true&allowPublicKeyRetrieval=true"
+  db.user = "{MySqlUserLogin}"
+  db.password = "{MySqlUserPassword}"
   db.driver = "com.mysql.cj.jdbc.Driver"
   profile = "slick.jdbc.MySQLProfile$"
   db.connectionTimeout = 15000

--- a/src/deploy-cromwell-on-azure/scripts/docker-compose.mysql.yml
+++ b/src/deploy-cromwell-on-azure/scripts/docker-compose.mysql.yml
@@ -7,7 +7,7 @@ services:
     image: "$MySqlImageName"
     environment:
       - MYSQL_ROOT_PASSWORD=cromwell
-      - MYSQL_DATABASE=cromwell_db
+      - MYSQL_DATABASE=$MySqlDatabaseName
     volumes:
       - type: bind
         source: /data/mysql

--- a/src/deploy-cromwell-on-azure/scripts/env-04-settings.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-04-settings.txt
@@ -9,4 +9,3 @@ BatchNodeAgentSkuId=batch.node.ubuntu 20.04
 MarthaUrl=
 MarthaKeyVaultName=
 MarthaSecretName=
-MySqlServerPassword={MySqlServerPassword}

--- a/src/deploy-cromwell-on-azure/scripts/env-13-my-sql-db.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-13-my-sql-db.txt
@@ -1,0 +1,3 @@
+﻿MySqlDatabaseName={MySqlDatabaseName}
+MySqlUserLogin={MySqlUserLogin}
+MySqlUserPassword={MySqlUserPassword}

--- a/src/deploy-cromwell-on-azure/scripts/mysql/init-user.sql
+++ b/src/deploy-cromwell-on-azure/scripts/mysql/init-user.sql
@@ -1,5 +1,5 @@
-CREATE USER 'cromwell'@'localhost' IDENTIFIED BY 'cromwell';
-GRANT ALL PRIVILEGES ON cromwell_db.* TO 'cromwell'@'localhost' WITH GRANT OPTION;
-CREATE USER 'cromwell'@'%' IDENTIFIED BY 'cromwell';
-GRANT ALL PRIVILEGES ON cromwell_db.* TO 'cromwell'@'%' WITH GRANT OPTION;
+CREATE USER '{MySqlUserLogin}'@'localhost' IDENTIFIED BY '{MySqlUserPassword}';
+GRANT ALL PRIVILEGES ON {MySqlDatabaseName}.* TO '{MySqlUserLogin}'@'localhost' WITH GRANT OPTION;
+CREATE USER '{MySqlUserLogin}'@'%' IDENTIFIED BY '{MySqlUserPassword}';
+GRANT ALL PRIVILEGES ON {MySqlDatabaseName}.* TO '{MySqlUserLogin}'@'%' WITH GRANT OPTION;
 FLUSH PRIVILEGES;

--- a/src/deploy-cromwell-on-azure/scripts/startup.sh
+++ b/src/deploy-cromwell-on-azure/scripts/startup.sh
@@ -97,10 +97,10 @@ write_log "Mounted containers:"
 findmnt -t fuse
 write_log
 
-k=docker-compose.*.yml
-readarray -t files < <(compgen -G "$k")
-k="${files[@]}"
-kv["COMPOSE_FILE"]="docker-compose.yml:${k//${IFS:0:1}/:}"
+compose_files=(docker-compose.*.yml)
+compose_files=("docker-compose.yml" "${compose_files[@]}")
+kv["COMPOSE_FILE"]=$(IFS=:; echo "${compose_files[*]}")
+
 rm -f .env && for key in "${!kv[@]}"; do echo "$key=${kv[$key]}" >> .env; done
 
 write_log "Running docker-compose pull"


### PR DESCRIPTION
This PR resolves #374 by creating a MySQL user account on the database instead of just using the administrator account, which is less secure. 