### PR TITLE
Make azure cli authentication explicit

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1809,7 +1809,7 @@ namespace CromwellOnAzureDeployer
         {
             try
             {
-                await Execute("Retrieving Azure management token...", () => new AzureServiceTokenProvider().GetAccessTokenAsync("https://management.azure.com/"));
+                await Execute("Retrieving Azure management token...", () => new AzureServiceTokenProvider("RunAs=Developer; DeveloperTool=AzureCli").GetAccessTokenAsync("https://management.azure.com/"));
             }
             catch (AzureServiceTokenProviderException ex)
             {

--- a/src/deploy-cromwell-on-azure/RefreshableAzureServiceTokenProvider.cs
+++ b/src/deploy-cromwell-on-azure/RefreshableAzureServiceTokenProvider.cs
@@ -35,7 +35,7 @@ namespace CromwellOnAzureDeployer
             this.resource = resource;
             this.tenantId = tenantId;
 
-            this.tokenProvider = new AzureServiceTokenProvider(azureAdInstance: azureAdInstance);
+            this.tokenProvider = new AzureServiceTokenProvider("RunAs=Developer; DeveloperTool=AzureCli", azureAdInstance: azureAdInstance);
         }
 
         /// <summary>


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/overview/azure/service-to-service-authentication#connection-string-support

By default, AzureServiceTokenProvider tries the following authentication methods, in order, to retrieve a token:

[A managed identity for Azure resources](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
Visual Studio authentication
[Azure CLI authentication](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli)

This results in unexpected behavior that if you run the Deployer on Azure VM and sign into az cli, it does not use the signed in user's account but it uses the managed identity of the VM instead. 