### PR TITLE
Create TES Db on Postgres

### DIFF
--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -12,11 +12,14 @@ namespace CromwellOnAzureDeployer
     public class Configuration : UserAccessibleConfiguration
     {
         public string PostgreSqlServerName { get; set; }
-        public string PostgreSqlDatabaseName { get; set; } = "cromwell_db";
+        public string PostgreSqlCromwellDatabaseName { get; set; } = "cromwell_db";
+        public string PostgreSqlTesDatabaseName { get; set; } = "tes_db";
         public string PostgreSqlAdministratorLogin { get; set; } = "coa_admin";
         public string PostgreSqlAdministratorPassword { get; set; }
-        public string PostgreSqlUserLogin { get; set; } = "cromwell";
-        public string PostgreSqlUserPassword { get; set; }
+        public string PostgreSqlCromwellUserLogin { get; set; } = "cromwell";
+        public string PostgreSqlCromwellUserPassword { get; set; }
+        public string PostgreSqlTesUserLogin { get; set; } = "tes";
+        public string PostgreSqlTesUserPassword { get; set; }
         public string PostgreSqlSkuName { get; set; } = "Standard_B2s";
         public string PostgreSqlTier { get; set; } = "Burstable";
         public string DefaultVmSubnetName { get; set; } = "vmsubnet";

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -333,7 +333,8 @@ namespace CromwellOnAzureDeployer
                         // Configuration preferences not currently settable by user.
                         configuration.PostgreSqlServerName = configuration.ProvisionPostgreSqlOnAzure.GetValueOrDefault() ? SdkContext.RandomResourceName($"{configuration.MainIdentifierPrefix}-", 15) : String.Empty;
                         configuration.PostgreSqlAdministratorPassword = Utility.GeneratePassword();
-                        configuration.PostgreSqlUserPassword = Utility.GeneratePassword();
+                        configuration.PostgreSqlCromwellUserPassword = Utility.GeneratePassword();
+                        configuration.PostgreSqlTesUserPassword = Utility.GeneratePassword();
 
                         if (string.IsNullOrWhiteSpace(configuration.BatchAccountName))
                         {
@@ -490,7 +491,7 @@ namespace CromwellOnAzureDeployer
 
                         if (configuration.ProvisionPostgreSqlOnAzure.GetValueOrDefault())
                         {
-                            await CreatePostgreSqlDatabaseUser(sshConnectionInfo);
+                            await CreatePostgreSqlCromwellDatabaseUser(sshConnectionInfo);
                         }
                     }
 
@@ -875,9 +876,12 @@ namespace CromwellOnAzureDeployer
             {
                 uploadList.Add((Utility.PersonalizeContent(new[]
                 {
-                    new Utility.ConfigReplaceTextItem("{PostgreSqlDatabaseName}", configuration.PostgreSqlDatabaseName),
-                    new Utility.ConfigReplaceTextItem("{PostgreSqlUserLogin}", configuration.PostgreSqlUserLogin),
-                    new Utility.ConfigReplaceTextItem("{PostgreSqlUserPassword}", configuration.PostgreSqlUserPassword),
+                    new Utility.ConfigReplaceTextItem("{PostgreSqlCromwellDatabaseName}", configuration.PostgreSqlCromwellDatabaseName),
+                    new Utility.ConfigReplaceTextItem("{PostgreSqlTesDatabaseName}", configuration.PostgreSqlTesDatabaseName),
+                    new Utility.ConfigReplaceTextItem("{PostgreSqlCromwellUserLogin}", configuration.PostgreSqlCromwellUserLogin),
+                    new Utility.ConfigReplaceTextItem("{PostgreSqlCromwellUserPassword}", configuration.PostgreSqlCromwellUserPassword),
+                    new Utility.ConfigReplaceTextItem("{PostgreSqlTesUserLogin}", configuration.PostgreSqlTesUserLogin),
+                    new Utility.ConfigReplaceTextItem("{PostgreSqlTesUserPassword}", configuration.PostgreSqlTesUserPassword),
                 }, "scripts", "env-13-postgre-sql-db.txt"),
                 $"{CromwellAzureRootDir}/env-13-postgre-sql-db.txt", false));
             }
@@ -1073,9 +1077,9 @@ namespace CromwellOnAzureDeployer
                     {
                         await UploadTextToStorageAccountAsync(storageAccount, ConfigurationContainerName, CromwellConfigurationFileName, Utility.PersonalizeContent(new[]
                         {
-                            new Utility.ConfigReplaceTextItem("{DatabaseUrl}", $"\"jdbc:postgresql://{configuration.PostgreSqlServerName}.postgres.database.azure.com/{configuration.PostgreSqlDatabaseName}?sslmode=require\""),
-                            new Utility.ConfigReplaceTextItem("{DatabaseUser}", $"\"{configuration.PostgreSqlUserLogin}\""),
-                            new Utility.ConfigReplaceTextItem("{DatabasePassword}", $"\"{configuration.PostgreSqlUserPassword}\""),
+                            new Utility.ConfigReplaceTextItem("{DatabaseUrl}", $"\"jdbc:postgresql://{configuration.PostgreSqlServerName}.postgres.database.azure.com/{configuration.PostgreSqlCromwellDatabaseName}?sslmode=require\""),
+                            new Utility.ConfigReplaceTextItem("{DatabaseUser}", $"\"{configuration.PostgreSqlCromwellUserLogin}\""),
+                            new Utility.ConfigReplaceTextItem("{DatabasePassword}", $"\"{configuration.PostgreSqlCromwellUserPassword}\""),
                             new Utility.ConfigReplaceTextItem("{DatabaseDriver}", $"\"org.postgresql.Driver\""),
                             new Utility.ConfigReplaceTextItem("{DatabaseProfile}", "\"slick.jdbc.PostgresProfile$\""),
                         }, "scripts", CromwellConfigurationFileName));
@@ -1157,9 +1161,15 @@ namespace CromwellOnAzureDeployer
                 });
 
             await Execute(
-                $"Creating PostgreSQL cromwell database: {configuration.PostgreSqlDatabaseName}...",
+                $"Creating PostgreSQL cromwell database: {configuration.PostgreSqlCromwellDatabaseName}...",
                 () => postgresManagementClient.Databases.CreateAsync(
-                    configuration.ResourceGroupName, configuration.PostgreSqlServerName, configuration.PostgreSqlDatabaseName,
+                    configuration.ResourceGroupName, configuration.PostgreSqlServerName, configuration.PostgreSqlCromwellDatabaseName,
+                    new Database()));
+
+            await Execute(
+                $"Creating PostgreSQL tes database: {configuration.PostgreSqlTesDatabaseName}...",
+                () => postgresManagementClient.Databases.CreateAsync(
+                    configuration.ResourceGroupName, configuration.PostgreSqlServerName, configuration.PostgreSqlTesDatabaseName,
                     new Database()));
 
             return server;
@@ -1307,13 +1317,13 @@ namespace CromwellOnAzureDeployer
                 () => networkInterface.Update().WithExistingNetworkSecurityGroup(networkSecurityGroup).ApplyAsync()
             );
 
-        private Task CreatePostgreSqlDatabaseUser(ConnectionInfo sshConnectionInfo)
+        private Task CreatePostgreSqlCromwellDatabaseUser(ConnectionInfo sshConnectionInfo)
             => Execute(
                 $"Creating PostgreSQL database user...",
                 () =>
                 {
-                    var sqlCommand = $"CREATE USER {configuration.PostgreSqlUserLogin} WITH PASSWORD '{configuration.PostgreSqlUserPassword}'; GRANT ALL PRIVILEGES ON DATABASE {configuration.PostgreSqlDatabaseName} TO {configuration.PostgreSqlUserLogin};";
-                    return ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"psql postgresql://{configuration.PostgreSqlAdministratorLogin}:{configuration.PostgreSqlAdministratorPassword}@{configuration.PostgreSqlServerName}.postgres.database.azure.com/{configuration.PostgreSqlDatabaseName} -c \"{sqlCommand}\"");
+                    var sqlCommand = $"CREATE USER {configuration.PostgreSqlCromwellUserLogin} WITH PASSWORD '{configuration.PostgreSqlCromwellUserPassword}'; GRANT ALL PRIVILEGES ON DATABASE {configuration.PostgreSqlCromwellDatabaseName} TO {configuration.PostgreSqlCromwellUserLogin};";
+                    return ExecuteCommandOnVirtualMachineAsync(sshConnectionInfo, $"psql postgresql://{configuration.PostgreSqlAdministratorLogin}:{configuration.PostgreSqlAdministratorPassword}@{configuration.PostgreSqlServerName}.postgres.database.azure.com/{configuration.PostgreSqlCromwellDatabaseName} -c \"{sqlCommand}\"");
                 }
             );
 

--- a/src/deploy-cromwell-on-azure/scripts/env-13-postgre-sql-db.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-13-postgre-sql-db.txt
@@ -1,3 +1,6 @@
-﻿PostgreSqlDatabaseName={PostgreSqlDatabaseName}
-PostgreSqlUserLogin={PostgreSqlUserLogin}
-PostgreSqlUserPassword={PostgreSqlUserPassword}
+﻿PostgreSqlCromwellDatabaseName={PostgreSqlCromwellDatabaseName}
+PostgreSqlTesDatabaseName={PostgreSqlTesDatabaseName}
+PostgreSqlCromwellUserLogin={PostgreSqlCromwellUserLogin}
+PostgreSqlCromwellUserPassword={PostgreSqlCromwellUserPassword}
+PostgreSqlTesUserLogin={PostgreSqlTesUserLogin}
+PostgreSqlTesUserPassword={PostgreSqlTesUserPassword}

--- a/src/deploy-cromwell-on-azure/scripts/startup.sh
+++ b/src/deploy-cromwell-on-azure/scripts/startup.sh
@@ -118,9 +118,9 @@ rm -f .env && for key in "${!kv[@]}"; do echo "$key=${kv[$key]}" >> .env; done
 
 if [ -n "$db_server_name" ]; then
     fully_qualified_server_name="$db_server_name.postgres.database.azure.com"
-    db_name=${kv["PostgreSqlDatabaseName"]}
-    db_user=${kv["PostgreSqlUserLogin"]}
-    db_user_password=${kv["PostgreSqlUserPassword"]}
+    db_name=${kv["PostgreSqlCromwellDatabaseName"]}
+    db_user=${kv["PostgreSqlCromwellUserLogin"]}
+    db_user_password=${kv["PostgreSqlCromwellUserPassword"]}
     write_log "Checking if database $db_name is locked"
     lockTableExists=$(psql -t -d "host='$fully_qualified_server_name' dbname=$db_name user=$db_user password=$db_user_password" -c "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name = 'databasechangeloglock'")
     [[ "$lockTableExists" -eq "1" ]] && isLocked=$(psql -t -d "host='$fully_qualified_server_name' dbname=$db_name user=$db_user password=$db_user_password" -c "SELECT CAST(locked AS INTEGER) FROM databasechangeloglock WHERE ID = 1") || isLocked=0


### PR DESCRIPTION
Resolves #385

This PR creates the TES database in the same server that hosts the Cromwell database. It is not hooked up to TES but the environment variables should be set so we can use them (eventually when we work on issue #386).

Scope: This PR should have minimal effect on the codebase as all changes are to the Postgres server behind a flag that's off by default. Default workflow ran fine, this change did not seem to affect the Cromwell stuff that does work. 
