### PR TITLE
ProvisionPostgreSqlOnAzure should be null be default or else update fails

### DIFF
--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -26,7 +26,7 @@ namespace CromwellOnAzureDeployer
         public string DefaultPostgreSqlSubnetName { get; set; } = "mysqlsubnet";
         public string PostgreSqlVersion { get; set; } = "11";
         public int PostgreSqlStorageSize { get; set; } = 128;  // GiB
-        public bool? ProvisionPostgreSqlOnAzure { get; set; } = false; // Will be accessible in 4.0 release
+        public bool? ProvisionPostgreSqlOnAzure { get; set; } // Will be accessible in 4.0 release
     }
     public abstract class UserAccessibleConfiguration
     {


### PR DESCRIPTION
When running the update command with the deployer, the following error occurs:

"ProvisionPostgreSqlOnAzure must not be provided when updating"

This is because ProvisionPostgreSqlOnAzure was set to false by default, instead of its default null

