### PR TITLE
Create Azure storage account as type LRS by default instead of GRS

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1021,6 +1021,7 @@ namespace CromwellOnAzureDeployer
                     .WithExistingResourceGroup(configuration.ResourceGroupName)
                     .WithGeneralPurposeAccountKindV2()
                     .WithOnlyHttpsTraffic()
+                    .WithSku(StorageAccountSkuType.Standard_LRS)
                     .CreateAsync(cts.Token));
 
         private async Task<IStorageAccount> GetExistingStorageAccountAsync(string storageAccountName)


### PR DESCRIPTION
Previously, the default Azure storage account that was created was of type GRS.  This PR is to change this to LRS, since LRS is less expensive and GRS is not needed for most scenarios.  Resolves #394 
