### PR TITLE
Check if managed identity exists before attempting to create it

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1446,6 +1446,7 @@ namespace CromwellOnAzureDeployer
                 async () =>
                 {
                     var identity = await azureSubscriptionClient.Identities.GetByResourceGroupAsync(configuration.ResourceGroupName, managedIdentityName);
+
                     if (identity != null)
                     {
                         return identity;

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1443,10 +1443,19 @@ namespace CromwellOnAzureDeployer
 
             return Execute(
                 $"Creating user-managed identity: {managedIdentityName}...",
-                () => azureSubscriptionClient.Identities.Define(managedIdentityName)
-                    .WithRegion(configuration.RegionName)
-                    .WithExistingResourceGroup(resourceGroup)
-                    .CreateAsync());
+                async () =>
+                {
+                    var identity = await azureSubscriptionClient.Identities.GetByResourceGroupAsync(configuration.ResourceGroupName, managedIdentityName);
+                    if (identity != null)
+                    {
+                        return identity;
+                    }
+
+                    return await azureSubscriptionClient.Identities.Define(managedIdentityName)
+                        .WithRegion(configuration.RegionName)
+                        .WithExistingResourceGroup(resourceGroup)
+                        .CreateAsync();
+                });
         }
 
         private Task<IIdentity> ReplaceSystemManagedIdentityWithUserManagedIdentityAsync(IResourceGroup resourceGroup, IVirtualMachine linuxVm)


### PR DESCRIPTION
Fixes issue #316. 

Deployer fails when ran multiple times with the same resource group. This fixes it by returning the existing managed id if it already exists. 