### PR TITLE
Support managedId or keyvault auth default containers

### DIFF
--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -251,6 +251,7 @@ string PostgreSqlServerName | Y | Y | N | Name of existing postgresql server.
 bool UsePostgreSqlSingleServer = false | Y | N | N | Use Postgresql single server rather than flexi servers, only recommended if you need to use private endpoints. 
 string KeyVaultName | Y | Y | N | Name of an existing key vault
 string UserObjectId | Y | N | N | ObjectId of the user running the deployer, can be found in AAD. Required to assign proper permissions to KeyVault when using AKS. 
+bool CrossSubscriptionAKSDeployment | Y | N | N | AKS cluster is in a different subscription than the storage account, so a keyvault and storage key will be used for storage auth for AKS.
 
 The following are more advanced configuration parameters:
 

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -61,6 +61,7 @@ namespace CromwellOnAzureDeployer
         public bool ManualHelmDeployment { get; set; }
         public string HelmBinaryPath { get; set; } = "C:\\ProgramData\\chocolatey\\bin\\helm.exe";
         public int AksPoolSize { get; set; } = 2;
+        public bool CrossSubscriptionAKSDeployment { get; set; } = false;
         public bool Silent { get; set; }
         public bool DeleteResourceGroupOnFailure { get; set; }
         public string CromwellVersion { get; set; }

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -160,7 +160,7 @@ namespace CromwellOnAzureDeployer
                 FlexibleServerModel.Server postgreSqlFlexServer = null;
                 SingleServerModel.Server postgreSqlSingleServer = null;
                 IStorageAccount storageAccount = null;
-                Vault keyVault = null;
+                string keyVaultUri = string.Empty;
                 IVirtualMachine linuxVm = null;
                 INetworkSecurityGroup networkSecurityGroup = null;
                 IIdentity managedIdentity = null;
@@ -301,12 +301,11 @@ namespace CromwellOnAzureDeployer
 
                         if (existingAksCluster is not null)
                         {
-                            if (!accountNames.TryGetValue("KeyVaultName", out var keyVaultName))
+                            if (accountNames.TryGetValue("KeyVaultName", out var keyVaultName))
                             {
-                                throw new ValidationException($"Could not retrieve the CosmosDb account name from virtual machine {configuration.VmName}.");
+                                var keyVault = await GetKeyVaultAsync(keyVaultName);
+                                keyVaultUri = keyVault.Properties.VaultUri;
                             }
-
-                            keyVault = await GetKeyVaultAsync(keyVaultName);
 
                             if (!accountNames.TryGetValue("ManagedIdentityClientId", out var managedIdentityClientId))
                             {
@@ -316,7 +315,7 @@ namespace CromwellOnAzureDeployer
                             managedIdentity = azureSubscriptionClient.Identities.ListByResourceGroup(configuration.ResourceGroupName).Where(id => id.ClientId == managedIdentityClientId).FirstOrDefault()
                                 ?? throw new ValidationException($"Managed Identity {managedIdentityClientId} does not exist in region {configuration.RegionName} or is not accessible to the current user.");
 
-                            await kubernetesManager.UpgradeAKSDeployment(accountNames, resourceGroup, storageAccount, managedIdentity, keyVault.Properties.VaultUri);
+                            await kubernetesManager.UpgradeAKSDeployment(accountNames, resourceGroup, storageAccount, managedIdentity, keyVaultUri);
                         }
                         else
                         {
@@ -332,7 +331,7 @@ namespace CromwellOnAzureDeployer
                         batchAccount = await ValidateAndGetExistingBatchAccountAsync();
                         aksCluster = await ValidateAndGetExistingAKSClusterAsync();
                         postgreSqlFlexServer = await ValidateAndGetExistingPostgresqlServer();
-                        keyVault = await ValidateAndGetExistingKeyVault();
+                        var keyVault = await ValidateAndGetExistingKeyVault();
 
                         // Configuration preferences not currently settable by user.
                         if (string.IsNullOrWhiteSpace(configuration.PostgreSqlServerName) && configuration.ProvisionPostgreSqlOnAzure.GetValueOrDefault())
@@ -453,13 +452,14 @@ namespace CromwellOnAzureDeployer
                             await AssignManagedIdOperatorToResourceAsync(managedIdentity, resourceGroup);
                         });
 
-                        if (configuration.UseAks)
+                        if (configuration.UseAks && configuration.CrossSubscriptionAKSDeployment)
                         {
                             await Task.Run(async () =>
                             {
                                 keyVault ??= await CreateKeyVaultAsync(configuration.KeyVaultName, managedIdentity, vnetAndSubnet.Value.vmSubnet);
+                                keyVaultUri = keyVault.Properties.VaultUri;
                                 var keys = await storageAccount.GetKeysAsync();
-                                await SetStorageKeySecret(keyVault.Properties.VaultUri, StorageAccountKeySecretName, keys.First().Value);
+                                await SetStorageKeySecret(keyVaultUri, StorageAccountKeySecretName, keys.First().Value);
                             });
                         }
 
@@ -487,7 +487,7 @@ namespace CromwellOnAzureDeployer
                                     await ProvisionManagedCluster(resourceGroup, managedIdentity, logAnalyticsWorkspace, vnetAndSubnet?.virtualNetwork, vnetAndSubnet?.vmSubnet.Name, configuration.PrivateNetworking.GetValueOrDefault());
                                 }
 
-                                await kubernetesManager.UpdateHelmValuesAsync(storageAccount.Name, keyVault.Properties.VaultUri, resourceGroup.Name, settings, managedIdentity);
+                                await kubernetesManager.UpdateHelmValuesAsync(storageAccount.Name, keyVaultUri, resourceGroup.Name, settings, managedIdentity);
 
                                 if (configuration.ManualHelmDeployment)
                                 {

--- a/src/deploy-cromwell-on-azure/KubernetesManager.cs
+++ b/src/deploy-cromwell-on-azure/KubernetesManager.cs
@@ -124,21 +124,24 @@ namespace CromwellOnAzureDeployer
             if (configuration.CrossSubscriptionAKSDeployment)
             {
                 values.InternalContainersKeyVaultAuth = new List<Dictionary<string, string>>();
+
                 foreach (var container in values.DefaultContainers)
                 {
                     var containerConfig = new Dictionary<string, string>()
-                {
-                    { "accountName",  storageAccountName },
-                    { "containerName", container },
-                    { "keyVaultURL", keyVaultUrl },
-                    { "keyVaultSecretName", Deployer.StorageAccountKeySecretName}
-                };
+                    {
+                        { "accountName",  storageAccountName },
+                        { "containerName", container },
+                        { "keyVaultURL", keyVaultUrl },
+                        { "keyVaultSecretName", Deployer.StorageAccountKeySecretName}
+                    };
+
                     values.InternalContainersKeyVaultAuth.Add(containerConfig);
                 }
             }
             else
             {
                 values.InternalContainersMIAuth = new List<Dictionary<string, string>>();
+
                 foreach (var container in values.DefaultContainers)
                 {
                     var containerConfig = new Dictionary<string, string>()
@@ -147,6 +150,7 @@ namespace CromwellOnAzureDeployer
                         { "containerName", container },
                         { "resourceGroup", resourceGroupName },
                     };
+
                     values.InternalContainersMIAuth.Add(containerConfig);
                 }
             }
@@ -252,7 +256,7 @@ namespace CromwellOnAzureDeployer
                 deployments = await client.AppsV1.ListNamespacedDeploymentAsync(configuration.AksCoANamespace, cancellationToken: cancellationToken);
                 deployment = deployments.Items.Where(x => x.Metadata.Name.Equals(deploymentName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 
-                if (deployment == null || deployment.Status == null || deployment.Status.ReadyReplicas == null || deployment.Status.ReadyReplicas < 1)
+                if ((deployment?.Status?.ReadyReplicas ?? 0) < 1)
                 {
                     throw new Exception("Workload not ready.");
                 }

--- a/src/deploy-cromwell-on-azure/KubernetesManager.cs
+++ b/src/deploy-cromwell-on-azure/KubernetesManager.cs
@@ -86,8 +86,6 @@ namespace CromwellOnAzureDeployer
         {
             var values = KubernetesYaml.Deserialize<HelmValues>(Utility.GetFileContent("scripts", "helm", "values-template.yaml"));
             values.Persistence["storageAccount"] = storageAccountName;
-            values.Persistence["keyVaultUrl"] = keyVaultUrl;
-            values.Persistence["keyVaultSecretName"] = Deployer.StorageAccountKeySecretName;
             values.Config["resourceGroup"] = resourceGroupName;
             values.Config["azureServicesAuthConnectionString"] = settings["AzureServicesAuthConnectionString"];
             values.Config["applicationInsightsAccountName"] = settings["ApplicationInsightsAccountName"];
@@ -121,6 +119,36 @@ namespace CromwellOnAzureDeployer
             else
             {
                 values.Images["cromwell"] = settings["CromwellImageName"];
+            }
+
+            if (configuration.CrossSubscriptionAKSDeployment)
+            {
+                values.InternalContainersKeyVaultAuth = new List<Dictionary<string, string>>();
+                foreach (var container in values.DefaultContainers)
+                {
+                    var containerConfig = new Dictionary<string, string>()
+                {
+                    { "accountName",  storageAccountName },
+                    { "containerName", container },
+                    { "keyVaultURL", keyVaultUrl },
+                    { "keyVaultSecretName", Deployer.StorageAccountKeySecretName}
+                };
+                    values.InternalContainersKeyVaultAuth.Add(containerConfig);
+                }
+            }
+            else
+            {
+                values.InternalContainersMIAuth = new List<Dictionary<string, string>>();
+                foreach (var container in values.DefaultContainers)
+                {
+                    var containerConfig = new Dictionary<string, string>()
+                    {
+                        { "accountName",  storageAccountName },
+                        { "containerName", container },
+                        { "resourceGroup", resourceGroupName },
+                    };
+                    values.InternalContainersMIAuth.Add(containerConfig);
+                }
             }
 
             await File.WriteAllTextAsync(Path.Join("scripts", "helm", "values.yaml"), KubernetesYaml.Serialize(values));
@@ -224,7 +252,7 @@ namespace CromwellOnAzureDeployer
                 deployments = await client.AppsV1.ListNamespacedDeploymentAsync(configuration.AksCoANamespace, cancellationToken: cancellationToken);
                 deployment = deployments.Items.Where(x => x.Metadata.Name.Equals(deploymentName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 
-                if (deployment.Status.ReadyReplicas == null || deployment.Status.ReadyReplicas < 1)
+                if (deployment == null || deployment.Status == null || deployment.Status.ReadyReplicas == null || deployment.Status.ReadyReplicas < 1)
                 {
                     throw new Exception("Workload not ready.");
                 }
@@ -247,6 +275,8 @@ namespace CromwellOnAzureDeployer
             public Dictionary<string, string> Config { get; set; }
             public Dictionary<string, string> Images { get; set; }
             public List<string> DefaultContainers { get; set; }
+            public List<Dictionary<string, string>> InternalContainersMIAuth { get; set; }
+            public List<Dictionary<string, string>> InternalContainersKeyVaultAuth { get; set; }
             public List<Dictionary<string, string>> ExternalContainers { get; set; }
             public List<Dictionary<string, string>> ExternalSasContainers { get; set; }
             public Dictionary<string, string> Persistence { get; set; }

--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/persistence.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/persistence.yaml
@@ -37,14 +37,56 @@ mountOptions:
 {{- $rg  := .Values.config.resourceGroup -}}
 {{- $namespace := .Values.config.coaNamespace -}}
 {{- $storageAccount  := .Values.persistence.storageAccount -}}
-{{- $keyVaultUrl  := .Values.persistence.keyVaultUrl -}}
-{{- $keyVaultSecretName  := .Values.persistence.keyVaultSecretName -}}
 {{- $size  := .Values.persistence.blobPvcSize -}}
-{{- range .Values.defaultContainers }}
+
+{{- range .Values.internalContainersMIAuth }}
+{{- $storageClassName := printf "blob-%s-%s" .accountName .containerName }}
+{{- $claimName := printf "%s-%s-claim1" .accountName .containerName }}
+{{- if eq $storageAccount .accountName }}
+  {{- $storageClassName = printf "blob-%s" .containerName}}
+  {{- $claimName = printf "%s-claim1" .containerName }}
+{{- end}}
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $storageClassName }}
+provisioner: blob.csi.azure.com
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+parameters:
+  resourceGroup: {{ .resourceGroup }}
+  storageAccount: {{ .accountName }}
+  containerName: {{ .containerName }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $claimName }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ $size }}
+  storageClassName: {{ $storageClassName }}
+---
+{{- end }}
+
+{{- range .Values.internalContainersKeyVaultAuth }}
+{{- $pvName := printf "pv-blob-%s-%s" .accountName .containerName }}
+{{- $claimName := printf "%s-%s-claim1" .accountName .containerName }}
+{{- $handleName := printf "pv-handle-%s-%s" .accountName .containerName }}
+{{- if eq $storageAccount .accountName }}
+  {{- $pvName = printf "pv-blob-%s" .containerName}}
+  {{- $claimName = printf "%s-claim1" .containerName }}
+  {{- $handleName = printf "pv-handle-%s" .containerName }}
+{{- end}}
+
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: pv-blob-{{ . }}
+  name: {{ $pvName }}
 spec:
   capacity:
     storage: {{ $size }}
@@ -57,27 +99,28 @@ spec:
     readOnly: false
     # make sure this volumeid is unique in the cluster
     # `#` is not allowed in self defined volumeHandle
-    volumeHandle: pv-handle-{{ . }}
+    volumeHandle: {{ $handleName }}
     volumeAttributes:
-      storageAccountName: {{ $storageAccount }}
-      containerName: {{ . }}
-      keyVaultURL: {{ $keyVaultUrl | quote }}
-      keyVaultSecretName: {{ $keyVaultSecretName }}
+      storageAccountName: {{ .accountName }}
+      containerName: {{ .containerName }}
+      keyVaultURL: {{ .keyVaultURL | quote }}
+      keyVaultSecretName: {{ .keyVaultSecretName }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ . }}-claim1
+  name: {{ $claimName }}
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: {{ $size }}
-  volumeName: pv-blob-{{ . }}
+  volumeName: {{ $pvName }}
   storageClassName: blob-fuse
 ---
 {{- end }}
+
 {{- range .Values.externalContainers }}
 apiVersion: v1
 data:
@@ -113,6 +156,7 @@ spec:
   storageClassName: blob-{{ .accountName }}-{{.containerName}}
 ---
 {{- end }}
+
 {{- range .Values.externalSasContainers }}
 apiVersion: v1
 data:

--- a/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
@@ -37,6 +37,17 @@ defaultContainers:
   - inputs
   - outputs
 
+internalContainersMIAuth:
+#  - accountName: storageAccount
+#    containerName: dataset1
+#    resourceGroup: resourceGroup1    
+
+internalContainersKeyVaultAuth:
+#  - accountName: storageAccount
+#    containerName: dataset1
+#    keyVaultURL: 
+#    keyVaultSecretName:
+
 externalContainers:
 #  - accountName: storageAccount
 #    accountKey: <key>
@@ -53,8 +64,6 @@ persistence:
   blobPvcSize: 32Gi
   cromwellTmpSize: 32Gi
   storageAccount: RUNTIME_PARAMETER
-  keyVaultUrl: RUNTIME_PARAMETER
-  keyVaultSecretName: RUNTIME_PARAMETER
 
 identity:
   name: RUNTIME_PARAMETER


### PR DESCRIPTION
Support arbitrarily many storage accounts using either managed ids or key vaults to authenticate. 
Refactor the default containers to use the new configuration depending on the CrossSubscriptionAKSDeployment flag.