### PR TITLE
Bug fix: support specifying an existing CosmosDB account

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -288,9 +288,8 @@ namespace CromwellOnAzureDeployer
                             throw new ValidationException($"Could not retrieve the CosmosDb account name from virtual machine {configuration.VmName}.");
                         }
 
-                        cosmosDb = (await azureSubscriptionClient.CosmosDBAccounts.ListByResourceGroupAsync(configuration.ResourceGroupName))
-                            .FirstOrDefault(a => a.Name.Equals(cosmosDbAccountName, StringComparison.OrdinalIgnoreCase))
-                                ?? throw new ValidationException($"CosmosDb account {cosmosDbAccountName} does not exist in resource group {configuration.ResourceGroupName}.");
+                        cosmosDb = await GetExistingCosmosDbAccountAsync(cosmosDbAccountName)
+                            ?? throw new ValidationException($"CosmosDb account {cosmosDbAccountName}, referenced by the VM configuration, does not exist in region {configuration.RegionName}");
 
                         configuration.CosmosDbAccountName = cosmosDbAccountName;
 

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1487,9 +1487,7 @@ namespace CromwellOnAzureDeployer
             {
                 try
                 {
-                    var list = await azureClient.WithSubscription(s).CosmosDBAccounts.ListAsync();
-                    var l = list.ToList();
-                    return l;
+                    return await azureClient.WithSubscription(s).CosmosDBAccounts.ListAsync();
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Previously, if a customer specified an existing CosmosDbAccountName value, it would have no effect.