### PR TITLE
Reduce deployer HTTP timeout and handle exceptions in AssignVmAsBillingReaderToSubscriptionAsync

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -78,6 +78,10 @@ namespace CromwellOnAzureDeployer
             .Handle<Exception>(ex => !(ex is SshAuthenticationException && ex.Message.StartsWith("Permission")))
             .WaitAndRetryAsync(5, retryAttempt => System.TimeSpan.FromSeconds(5));
 
+        private static readonly AsyncRetryPolicy generalRetryPolicy = Policy
+            .Handle<Exception>()
+            .WaitAndRetryAsync(3, retryAttempt => System.TimeSpan.FromSeconds(1));
+
         public const string WorkflowsContainerName = "workflows";
         public const string ConfigurationContainerName = "configuration";
         public const string CromwellConfigurationFileName = "cromwell-application.conf";
@@ -1688,14 +1692,14 @@ namespace CromwellOnAzureDeployer
             return server;
         }
 
-        private Task AssignVmAsBillingReaderToSubscriptionAsync(IIdentity managedIdentity)
+        private async Task AssignVmAsBillingReaderToSubscriptionAsync(IIdentity managedIdentity)
         {
             try
             {
-                return Execute(
+                await Execute(
                     $"Assigning {BuiltInRole.BillingReader} role for VM to Subscription scope...",
                     () => roleAssignmentHashConflictRetryPolicy.ExecuteAsync(
-                        () => azureSubscriptionClient.AccessManagement.RoleAssignments
+                        async () => await azureSubscriptionClient.AccessManagement.RoleAssignments
                             .Define(Guid.NewGuid().ToString())
                             .ForObjectId(managedIdentity.PrincipalId)
                             .WithBuiltInRole(BuiltInRole.BillingReader)
@@ -1705,7 +1709,6 @@ namespace CromwellOnAzureDeployer
             catch (Microsoft.Rest.Azure.CloudException)
             {
                 DisplayBillingReaderInsufficientAccessLevelWarning();
-                return Task.CompletedTask;
             }
         }
 
@@ -2536,9 +2539,11 @@ namespace CromwellOnAzureDeployer
 
         private async Task ValidateVmAsync()
         {
-            var computeSkus = (await azureSubscriptionClient.ComputeSkus.ListByRegionAsync(configuration.RegionName))
-                .Where(s => s.ResourceType == ComputeResourceType.VirtualMachines && !s.Restrictions.Any())
-                .Select(s => s.Name.ToString())
+            var computeSkusRaw = await generalRetryPolicy.ExecuteAsync(() => azureSubscriptionClient.ComputeSkus.ListbyRegionAndResourceTypeAsync(Region.Create(configuration.RegionName), ComputeResourceType.VirtualMachines));
+            
+            var computeSkus = computeSkusRaw
+                .Where(s => !s.Restrictions.Any())
+                .Select(s => s.Name.Value)
                 .ToList();
 
             if (!computeSkus.Any())

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -2539,9 +2539,10 @@ namespace CromwellOnAzureDeployer
 
         private async Task ValidateVmAsync()
         {
-            var computeSkusRaw = await generalRetryPolicy.ExecuteAsync(() => azureSubscriptionClient.ComputeSkus.ListbyRegionAndResourceTypeAsync(Region.Create(configuration.RegionName), ComputeResourceType.VirtualMachines));
-            
-            var computeSkus = computeSkusRaw
+            var computeSkus = (await generalRetryPolicy.ExecuteAsync(() => 
+                azureSubscriptionClient.ComputeSkus.ListbyRegionAndResourceTypeAsync(
+                    Region.Create(configuration.RegionName), 
+                    ComputeResourceType.VirtualMachines)))
                 .Where(s => !s.Restrictions.Any())
                 .Select(s => s.Name.Value)
                 .ToList();

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1699,7 +1699,7 @@ namespace CromwellOnAzureDeployer
                 await Execute(
                     $"Assigning {BuiltInRole.BillingReader} role for VM to Subscription scope...",
                     () => roleAssignmentHashConflictRetryPolicy.ExecuteAsync(
-                        async () => await azureSubscriptionClient.AccessManagement.RoleAssignments
+                        () => azureSubscriptionClient.AccessManagement.RoleAssignments
                             .Define(Guid.NewGuid().ToString())
                             .ForObjectId(managedIdentity.PrincipalId)
                             .WithBuiltInRole(BuiltInRole.BillingReader)


### PR DESCRIPTION
These changes will reduce the likelihood of the deployer experiencing an HTTP timeout