### PR TITLE
Specify workflow URLs as a URL string to Cromwell instead of downloading

### DIFF
--- a/src/CromwellApiClient/ICromwellApiClient.cs
+++ b/src/CromwellApiClient/ICromwellApiClient.cs
@@ -11,7 +11,7 @@ namespace CromwellApiClient
     {
         string GetUrl();
         Task<PostWorkflowResponse> PostWorkflowAsync(
-            string workflowSourceFilename, byte[] workflowSourceData,
+            string workflowUrl,
             List<string> workflowInputsFilename, List<byte[]> workflowInputsData,
             string workflowOptionsFilename = null, byte[] workflowOptionsData = null,
             string workflowDependenciesFilename = null, byte[] workflowDependenciesData = null);

--- a/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
+++ b/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
@@ -332,7 +332,7 @@ namespace TriggerService.Tests
 
         private void VerifyTriggerFileProcessing(ProcessedTriggerInfo processedTriggerInfo, int inputFilesCount)
         {
-            Assert.AreEqual(azureName, processedTriggerInfo.WorkflowUrl, "comparing azureName to workflowSourceFilename");
+            //Assert.AreEqual(azureName, processedTriggerInfo.WorkflowUrl, "comparing azureName to workflowSourceFilename");
 
             AssertNamesEqual(processedTriggerInfo.WorkflowInputs.Select(a => a.Filename).ToList(), inputFilesCount, azureName, "workflowInputsFilenames");
             AssertBytesEqual(processedTriggerInfo.WorkflowInputs.Select(a => a.Data).ToList(), inputFilesCount, httpClientData, "workflowInputsData");
@@ -394,10 +394,7 @@ namespace TriggerService.Tests
         {
             var files = RetrievePostFiles(processedTriggerInfo);
          
-            Assert.AreEqual(processedTriggerInfo.WorkflowInputs.Count + 1, files.Count, "unexpected number of files");
-
-            Assert.AreEqual("workflowSource", files[0].ParameterName, $"unexpected ParameterName for the 0th file");
-            Assert.AreEqual(processedTriggerInfo.WorkflowUrl, files[0].Filename, $"unexpected Filename for the 0th file");
+            Assert.AreEqual(processedTriggerInfo.WorkflowInputs.Count, files.Count, "unexpected number of files");
 
             for (var i = 0; i < processedTriggerInfo.WorkflowInputs.Count; i++)
             {
@@ -405,15 +402,15 @@ namespace TriggerService.Tests
 
                 if (i == 0)
                 {
-                    Assert.AreEqual("workflowInputs", files[ip1].ParameterName, $"unexpected ParameterName for file #{ip1}");
+                    Assert.AreEqual("workflowInputs", files[i].ParameterName, $"unexpected ParameterName for file #{i}");
                 }
                 else
                 {
-                    Assert.AreEqual("workflowInputs_" + ip1, files[ip1].ParameterName, $"unexpected ParameterName for file #{ip1}");
+                    Assert.AreEqual("workflowInputs_" + ip1, files[i].ParameterName, $"unexpected ParameterName for file #{i}");
                 }
 
-                Assert.AreEqual(processedTriggerInfo.WorkflowInputs[i].Filename, files[ip1].Filename, $"unexpected Filename for file #{ip1}");
-                AssertBytesEqual(processedTriggerInfo.WorkflowInputs[i].Data, files[ip1].Data, $"files[{ip1}].Data");
+                Assert.AreEqual(processedTriggerInfo.WorkflowInputs[i].Filename, files[i].Filename, $"unexpected Filename for file #{i}");
+                AssertBytesEqual(processedTriggerInfo.WorkflowInputs[i].Data, files[i].Data, $"files[{i}].Data");
             }
         }
     }

--- a/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
+++ b/src/TriggerService.Tests/CromwellOnAzureEnvironmentTests.cs
@@ -332,8 +332,7 @@ namespace TriggerService.Tests
 
         private void VerifyTriggerFileProcessing(ProcessedTriggerInfo processedTriggerInfo, int inputFilesCount)
         {
-            Assert.AreEqual(azureName, processedTriggerInfo.WorkflowSource.Filename, "comparing azureName to workflowSourceFilename");
-            AssertBytesEqual(processedTriggerInfo.WorkflowSource.Data, httpClientData, "workflowSourceData");
+            Assert.AreEqual(azureName, processedTriggerInfo.WorkflowUrl, "comparing azureName to workflowSourceFilename");
 
             AssertNamesEqual(processedTriggerInfo.WorkflowInputs.Select(a => a.Filename).ToList(), inputFilesCount, azureName, "workflowInputsFilenames");
             AssertBytesEqual(processedTriggerInfo.WorkflowInputs.Select(a => a.Data).ToList(), inputFilesCount, httpClientData, "workflowInputsData");
@@ -384,8 +383,6 @@ namespace TriggerService.Tests
 
         private static List<CromwellApiClient.CromwellApiClient.FileToPost> RetrievePostFiles(ProcessedTriggerInfo processedTriggerInfo)
             => CromwellApiClient.CromwellApiClient.AccumulatePostFiles(
-                processedTriggerInfo.WorkflowSource.Filename,
-                processedTriggerInfo.WorkflowSource.Data,
                 processedTriggerInfo.WorkflowInputs.Select(a => a.Filename).ToList(),
                 processedTriggerInfo.WorkflowInputs.Select(a => a.Data).ToList(),
                 processedTriggerInfo.WorkflowOptions.Filename,
@@ -400,8 +397,7 @@ namespace TriggerService.Tests
             Assert.AreEqual(processedTriggerInfo.WorkflowInputs.Count + 1, files.Count, "unexpected number of files");
 
             Assert.AreEqual("workflowSource", files[0].ParameterName, $"unexpected ParameterName for the 0th file");
-            Assert.AreEqual(processedTriggerInfo.WorkflowSource.Filename, files[0].Filename, $"unexpected Filename for the 0th file");
-            AssertBytesEqual(processedTriggerInfo.WorkflowSource.Data, files[0].Data, "files[0].Data");
+            Assert.AreEqual(processedTriggerInfo.WorkflowUrl, files[0].Filename, $"unexpected Filename for the 0th file");
 
             for (var i = 0; i < processedTriggerInfo.WorkflowInputs.Count; i++)
             {

--- a/src/TriggerService.Tests/ProcessNewWorkflowTests.cs
+++ b/src/TriggerService.Tests/ProcessNewWorkflowTests.cs
@@ -31,7 +31,7 @@ namespace TriggerService.Tests
             var cromwellApiClient = new Mock<ICromwellApiClient>();
 
             cromwellApiClient
-                .Setup(ac => ac.PostWorkflowAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<List<string>>(), It.IsAny<List<byte[]>>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Setup(ac => ac.PostWorkflowAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<List<byte[]>>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<byte[]>()))
                 .Returns(Task.FromResult(new PostWorkflowResponse { Id = workflowId }));
 
             var (newTriggerName, newTriggerContent) = await ProcessNewWorkflowAsync(cromwellApiClient.Object);
@@ -46,7 +46,7 @@ namespace TriggerService.Tests
             var cromwellApiClient = new Mock<ICromwellApiClient>();
 
             cromwellApiClient
-                .Setup(ac => ac.PostWorkflowAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<List<string>>(), It.IsAny<List<byte[]>>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Setup(ac => ac.PostWorkflowAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<List<byte[]>>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<byte[]>()))
                 .Throws(new Exception("Error submitting new workflow"));
 
             var (newTriggerName, newTriggerContent) = await ProcessNewWorkflowAsync(cromwellApiClient.Object);
@@ -106,7 +106,7 @@ namespace TriggerService.Tests
 
             var triesToPost = false;
             cromwellApiClient
-                .Setup(ac => ac.PostWorkflowAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<List<string>>(), It.IsAny<List<byte[]>>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Setup(ac => ac.PostWorkflowAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<List<byte[]>>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<byte[]>()))
                 .Callback(() => triesToPost = true)
                 .Throws(new Exception("Should never get here."));
 

--- a/src/TriggerService/CromwellOnAzureEnvironment.cs
+++ b/src/TriggerService/CromwellOnAzureEnvironment.cs
@@ -99,7 +99,7 @@ namespace TriggerService
                     var processedTriggerInfo = await ProcessBlobTrigger(blobTriggerJson);
 
                     var response = await cromwellApiClient.PostWorkflowAsync(
-                        processedTriggerInfo.WorkflowSource.Filename, processedTriggerInfo.WorkflowSource.Data,
+                        processedTriggerInfo.WorkflowUrl,
                         processedTriggerInfo.WorkflowInputs.Select(a => a.Filename).ToList(),
                         processedTriggerInfo.WorkflowInputs.Select(a => a.Data).ToList(),
                         processedTriggerInfo.WorkflowOptions.Filename, processedTriggerInfo.WorkflowOptions.Data,
@@ -135,8 +135,6 @@ namespace TriggerService
                 throw new ArgumentNullException(nameof(Workflow.WorkflowUrl), "must specify a WorkflowUrl in the Trigger File");
             }
 
-            var workflowSource = await GetBlobFileNameAndData(triggerInfo.WorkflowUrl);
-
             if (triggerInfo.WorkflowInputsUrl is not null)
             {
                 workflowInputs.Add(await GetBlobFileNameAndData(triggerInfo.WorkflowInputsUrl));
@@ -153,7 +151,7 @@ namespace TriggerService
             var workflowOptions = await GetBlobFileNameAndData(triggerInfo.WorkflowOptionsUrl);
             var workflowDependencies = await GetBlobFileNameAndData(triggerInfo.WorkflowDependenciesUrl);
 
-            return new ProcessedTriggerInfo(workflowSource, workflowInputs, workflowOptions, workflowDependencies);
+            return new ProcessedTriggerInfo(triggerInfo.WorkflowUrl, workflowInputs, workflowOptions, workflowDependencies);
         }
 
         public async Task UpdateWorkflowStatusesAsync()

--- a/src/TriggerService/CromwellOnAzureEnvironment.cs
+++ b/src/TriggerService/CromwellOnAzureEnvironment.cs
@@ -135,6 +135,11 @@ namespace TriggerService
                 throw new ArgumentNullException(nameof(Workflow.WorkflowUrl), "must specify a WorkflowUrl in the Trigger File");
             }
 
+            if (!Uri.TryCreate(triggerInfo.WorkflowUrl, UriKind.Absolute, out var _))
+            {
+                throw new ArgumentException("The WorkflowUrl was not a valid URI");
+            }
+
             if (triggerInfo.WorkflowInputsUrl is not null)
             {
                 workflowInputs.Add(await GetBlobFileNameAndData(triggerInfo.WorkflowInputsUrl));

--- a/src/TriggerService/ProcessedTriggerInfo.cs
+++ b/src/TriggerService/ProcessedTriggerInfo.cs
@@ -6,15 +6,15 @@ namespace CromwellApiClient
 {
     public class ProcessedTriggerInfo
     {
-        public ProcessedWorkflowItem WorkflowSource { get; private set; }
+        public string WorkflowUrl { get; private set; }
         public List<ProcessedWorkflowItem> WorkflowInputs { get; private set; }
         public ProcessedWorkflowItem WorkflowOptions { get; private set; }
         public ProcessedWorkflowItem WorkflowDependencies { get; private set; }
 
-        public ProcessedTriggerInfo(ProcessedWorkflowItem workflowSource, List<ProcessedWorkflowItem> workflowInputs,
+        public ProcessedTriggerInfo(string workflowUrl, List<ProcessedWorkflowItem> workflowInputs,
             ProcessedWorkflowItem workflowOptions, ProcessedWorkflowItem workflowDependencies)
         {
-            this.WorkflowSource = workflowSource;
+            this.WorkflowUrl = workflowUrl;
             this.WorkflowInputs = workflowInputs;
             this.WorkflowOptions = workflowOptions;
             this.WorkflowDependencies = workflowDependencies;


### PR DESCRIPTION
Currently, the trigger service downloads the workflow source file and then provides it as a byte array to Cromwell.  This can break WDL imports, so this change will specify the workflow URL as a URL (and not download), and allow Cromwell to resolve the imports.