### PR TITLE
Truncate long Cromwell failure messages

### DIFF
--- a/src/TriggerService/TriggerHostedService.cs
+++ b/src/TriggerService/TriggerHostedService.cs
@@ -521,7 +521,7 @@ namespace TriggerService
                 {
                     if (metadataFailures[i].Message?.Length > maxFailureMessageLength)
                     {
-                        metadataFailures[i].Message = metadataFailures[i].Message[..maxFailureMessageLength];
+                        metadataFailures[i].Message = $"{metadataFailures[i].Message[..maxFailureMessageLength]} [TRUNCATED by Cromwell On Azure's Trigger Service]";
                     }
                 }
             }

--- a/src/TriggerService/TriggerHostedService.cs
+++ b/src/TriggerService/TriggerHostedService.cs
@@ -508,10 +508,23 @@ namespace TriggerService
         private async Task<WorkflowFailureInfo> GetWorkflowFailureInfoAsync(Guid workflowId, string metadata)
         {
             const string BatchExecutionDirectoryName = "__batch";
+            const int maxFailureMessageLength = 4096;
 
             var metadataFailures = string.IsNullOrWhiteSpace(metadata)
                 ? default
                 : JsonConvert.DeserializeObject<CromwellMetadata>(metadata)?.Failures;
+
+            if (metadataFailures?.Count > 0)
+            {
+                // Truncate failure messages; some can be 56k+ when it's an HTML message
+                for (int i = 0; i < metadataFailures.Count; i++)
+                {
+                    if (metadataFailures[i].Message?.Length > maxFailureMessageLength)
+                    {
+                        metadataFailures[i].Message = metadataFailures[i].Message[..maxFailureMessageLength];
+                    }
+                }
+            }
 
             var tesTasks = await tesTaskRepository.GetItemsAsync(t => t.WorkflowId == workflowId.ToString());
 


### PR DESCRIPTION
Some failure messages are 56k+ when it's an HTML error page from github