### PR TITLE
Restore access to task-level std{out|err}.txt for failed tasks in failed workflows

### DIFF
--- a/src/TriggerService.Tests/UpdateWorkflowStatusTests.cs
+++ b/src/TriggerService.Tests/UpdateWorkflowStatusTests.cs
@@ -60,8 +60,8 @@ namespace TriggerService.Tests
             Assert.AreEqual("FailureExitCode", failedTask?.FailureReason);
             Assert.AreEqual(1, failedTask?.SystemLogs?.Count);
             Assert.AreEqual("The task process exited with an unexpected exit code", failedTask?.SystemLogs.First());
-            Assert.AreEqual("execution/__batch/stdout.txt", failedTask.StdOut);
-            Assert.AreEqual("execution/__batch/stderr.txt", failedTask.StdErr);
+            Assert.AreEqual($"/tes-internal/{tesTasks.First().Id}/stdout.txt", failedTask.StdOut);
+            Assert.AreEqual($"/tes-internal/{tesTasks.First().Id}/stderr.txt", failedTask.StdErr);
         }
 
         [TestMethod]

--- a/src/TriggerService/TriggerHostedService.cs
+++ b/src/TriggerService/TriggerHostedService.cs
@@ -527,7 +527,6 @@ namespace TriggerService
 
         private async Task<WorkflowFailureInfo> GetWorkflowFailureInfoAsync(Guid workflowId, string metadata)
         {
-            const string BatchExecutionDirectoryName = "__batch";
             const int maxFailureMessageLength = 4096;
 
             var metadataFailures = string.IsNullOrWhiteSpace(metadata)
@@ -559,8 +558,9 @@ namespace TriggerService
                     var cromwellScriptFailed = t.CromwellResultCode.GetValueOrDefault() != 0;
                     var batchTaskFailed = (t.Logs?.LastOrDefault()?.Logs?.LastOrDefault()?.ExitCode).GetValueOrDefault() != 0;
                     var executor = t.Executors?.LastOrDefault();
-                    var executionDirectoryPath = GetParentPath(executor?.Stdout);
-                    var batchExecutionDirectoryPath = executionDirectoryPath is not null ? $"{executionDirectoryPath}/{BatchExecutionDirectoryName}" : null;
+                    var batchExecutionDirectoryPath = t.Resources?.BackendParameters?.ContainsKey(nameof(TesResources.SupportedBackendParameters.internal_path_prefix)) ?? false
+                        ? $"/{t.Resources.BackendParameters[nameof(TesResources.SupportedBackendParameters.internal_path_prefix)].Trim('/')}"
+                        : $"/tes-internal/{t.Id}";
                     var batchStdOut = batchExecutionDirectoryPath is not null ? $"{batchExecutionDirectoryPath}/stdout.txt" : null;
                     var batchStdErr = batchExecutionDirectoryPath is not null ? $"{batchExecutionDirectoryPath}/stderr.txt" : null;
 


### PR DESCRIPTION
Addresses  microsoft/ga4gh-tes#243