### PR TITLE
Support for shared external AKS cluster

### DIFF
--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -330,7 +330,7 @@ namespace CromwellOnAzureDeployer
                         if (aksCluster is not null)
                         {
                             aksNodepoolIdentity = await GetUserManagedIdentityAsync(aksCluster.Identity.UserAssignedIdentities.First().Value.PrincipalId);
-                            
+
                             var aksSubnet = aksCluster.AgentPoolProfiles.Where(x => string.Equals(x.Mode, "System", StringComparison.OrdinalIgnoreCase)).First().VnetSubnetID;
                             var aksVnetString = aksSubnet.Remove(aksSubnet.IndexOf("/subnets/"));
                             aksVnet = await azureSubscriptionClient.Networks.GetByIdAsync(aksVnetString);
@@ -1398,7 +1398,7 @@ namespace CromwellOnAzureDeployer
         {
             var dnsZones = (await azureSubscriptionClient.PrivateDnsZones.ListAsync()).Where(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
             var dnsZonesMap = new Dictionary<string, IPrivateDnsZone>();
-            
+
             foreach (var zone in dnsZones)
             {
                 var pairs = zone.VirtualNetworkLinks.List().Select(x => new KeyValuePair<string, IPrivateDnsZone>(x.ReferencedVirtualNetworkId, zone));

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -2060,6 +2060,11 @@ namespace CromwellOnAzureDeployer
             {
                 throw new Exception("Invalid configuration options BatchNodesSubnetId and BatchSubnetName are mutually exclusive.");
             }
+
+            if (!string.IsNullOrWhiteSpace(configuration.AksClusterName) && !configuration.UsePostgreSqlSingleServer)
+            {
+                throw new Exception("If providing an existing AKS cluster, --UsePostgreSqlSingleServer must be set to true.");
+            }
         }
 
         private static void DisplayValidationExceptionAndExit(ValidationException validationException)

--- a/src/deploy-cromwell-on-azure/KubernetesManager.cs
+++ b/src/deploy-cromwell-on-azure/KubernetesManager.cs
@@ -194,7 +194,6 @@ namespace CromwellOnAzureDeployer
             await Deployer.UploadTextToStorageAccountAsync(storageAccount, Deployer.ConfigurationContainerName, "aksValues.yaml", valuesString, cts.Token);
         }
 
-
         public async Task UpgradeValuesYamlAsync(IStorageAccount storageAccount, Dictionary<string, string> settings, List<MountableContainer> containersToMount, Version previousVersion)
         {
             var values = KubernetesYaml.Deserialize<HelmValues>(await Deployer.DownloadTextFromStorageAccountAsync(storageAccount, Deployer.ConfigurationContainerName, "aksValues.yaml", cts));

--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/cromwell-deployment.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/cromwell-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $namespace := .Values.config.coaNamespace -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -59,7 +60,7 @@ spec:
   {{- $claimName = printf "%s-claim1" .containerName }}
 {{- end}}
             - mountPath: {{ $path }}
-              name: {{ $claimName }}
+              name: {{ $namespace }}-{{ $claimName }}
 {{- end }}
 {{- range .Values.internalContainersKeyVaultAuth }}
 {{- $path := printf "/%s/%s" .accountName .containerName }}
@@ -69,15 +70,15 @@ spec:
   {{- $claimName = printf "%s-claim1" .containerName }}
 {{- end}}
             - mountPath: {{ $path }}
-              name: {{ $claimName }}
+              name: {{ $namespace }}-{{ $claimName }}
 {{- end}}
 {{- range .Values.externalContainers }}
             - mountPath: /{{.accountName}}/{{.containerName}}
-              name: {{.accountName}}-{{.containerName}}-claim1
+              name: {{ $namespace }}-{{.accountName}}-{{.containerName}}-claim1
 {{- end }}
 {{- range .Values.externalSasContainers }}
             - mountPath: /{{.accountName}}/{{.containerName}}
-              name: {{.accountName}}-{{.containerName}}-claim1
+              name: {{ $namespace }}-{{.accountName}}-{{.containerName}}-claim1
 {{- end }}
       restartPolicy: Always
       volumes:
@@ -89,27 +90,27 @@ spec:
 {{- if and (eq (lower $storageAccount) (lower .accountName)) (has (lower .containerName) $cromwellContainers)}}
   {{- $claimName = printf "%s-claim1" .containerName }}
 {{- end}}
-        - name: {{ $claimName }}
+        - name: {{ $namespace }}-{{ $claimName }}
           persistentVolumeClaim:
-            claimName: {{ $claimName }}
+            claimName: {{ $namespace }}-{{ $claimName }}
 {{- end }}
 {{- range .Values.internalContainersKeyVaultAuth }}
 {{- $claimName := printf "%s-%s-claim1" .accountName .containerName }}
 {{- if and (eq (lower $storageAccount) (lower .accountName)) (has (lower .containerName) $cromwellContainers)}}
   {{- $claimName = printf "%s-claim1" .containerName }}
 {{- end}}
-        - name: {{ $claimName }}
+        - name: {{ $namespace }}-{{ $claimName }}
           persistentVolumeClaim:
-            claimName: {{ $claimName }}
+            claimName: {{ $namespace }}-{{ $claimName }}
 {{- end }}
 {{- range .Values.externalContainers }}
-        - name: {{.accountName}}-{{.containerName}}-claim1
+        - name: {{ $namespace }}-{{.accountName}}-{{.containerName}}-claim1
           persistentVolumeClaim:
-            claimName: {{.accountName}}-{{.containerName}}-claim1
+            claimName: {{ $namespace }}-{{.accountName}}-{{.containerName}}-claim1
 {{- end }}
 {{- range .Values.externalSasContainers }}
-        - name: {{.accountName}}-{{.containerName}}-claim1
+        - name: {{ $namespace }}-{{.accountName}}-{{.containerName}}-claim1
           persistentVolumeClaim:
-            claimName: {{.accountName}}-{{.containerName}}-claim1
+            claimName: {{ $namespace }}-{{.accountName}}-{{.containerName}}-claim1
 {{- end }}
 status: {}

--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/persistence.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/persistence.yaml
@@ -1,4 +1,5 @@
-﻿apiVersion: v1
+﻿{{- $namespace := .Values.config.coaNamespace -}}
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   creationTimestamp: null
@@ -16,7 +17,7 @@ status: {}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: blob-fuse
+  name: {{ $namespace }}-blob-fuse
 provisioner: blob.csi.azure.com
 parameters:
   skuName: Premium_LRS  # available values: Standard_LRS, Premium_LRS, Standard_GRS, Standard_RAGRS
@@ -35,7 +36,7 @@ mountOptions:
   - --cache-size-mb=1000  # Default will be 80% of available memory, eviction will happen beyond that.
 ---
 {{- $rg  := .Values.config.resourceGroup -}}
-{{- $namespace := .Values.config.coaNamespace -}}
+
 {{- $storageAccount  := .Values.persistence.storageAccount -}}
 {{- $size  := .Values.persistence.blobPvcSize -}}
 {{- $cromwellContainers  := .Values.cromwellContainers -}}
@@ -51,7 +52,7 @@ mountOptions:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $storageClassName }}
+  name: {{ $namespace }}-{{ $storageClassName }}
 provisioner: blob.csi.azure.com
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -66,14 +67,14 @@ mountOptions:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $claimName }}
+  name: {{ $namespace }}-{{ $claimName }}
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: {{ $size }}
-  storageClassName: {{ $storageClassName }}
+  storageClassName: {{ $namespace }}-{{ $storageClassName }}
 ---
 {{- end }}
 
@@ -90,14 +91,14 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ $pvName }}
+  name: {{ $namespace }}-{{ $pvName }}
 spec:
   capacity:
     storage: {{ $size }}
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain  # If set as "Delete" container would be removed after pvc deletion
-  storageClassName: blob-fuse
+  storageClassName: {{ $namespace }}-blob-fuse
   mountOptions:
     - -o allow_other
     - --file-cache-timeout-in-seconds=120
@@ -116,15 +117,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $claimName }}
+  name: {{ $namespace }}-{{ $claimName }}
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: {{ $size }}
-  volumeName: {{ $pvName }}
-  storageClassName: blob-fuse
+  volumeName: {{ $namespace }}-{{ $pvName }}
+  storageClassName: {{ $namespace }}-blob-fuse
 ---
 {{- end }}
 
@@ -135,13 +136,13 @@ data:
   azurestorageaccountkey: {{.accountKey | b64enc}}
 kind: Secret
 metadata:
-  name: sa-secret-{{ .accountName }}-{{.containerName}}
+  name: {{ $namespace }}-sa-secret-{{ .accountName }}-{{.containerName}}
 type: Opaque
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: blob-{{ .accountName }}-{{.containerName}}
+  name: {{ $namespace }}-blob-{{ .accountName }}-{{.containerName}}
 provisioner: blob.csi.azure.com
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -156,14 +157,14 @@ mountOptions:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .accountName }}-{{ .containerName }}-claim1
+  name: {{ $namespace }}-{{ .accountName }}-{{ .containerName }}-claim1
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: {{ $size }}
-  storageClassName: blob-{{ .accountName }}-{{.containerName}}
+  storageClassName: {{ $namespace }}-blob-{{ .accountName }}-{{.containerName}}
 ---
 {{- end }}
 
@@ -174,13 +175,13 @@ data:
   azurestorageaccountsastoken: {{.sasToken | b64enc}}
 kind: Secret
 metadata:
-  name: sa-secret-{{ .accountName }}-{{ .containerName }}
+  name: {{ $namespace }}-sa-secret-{{ .accountName }}-{{ .containerName }}
 type: Opaque
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: pv-blob-{{ .accountName }}-{{ .containerName }}
+  name: {{ $namespace }}-pv-blob-{{ .accountName }}-{{ .containerName }}
 spec:
   capacity:
     storage: {{ $size }}
@@ -193,24 +194,24 @@ spec:
   csi:
     driver: blob.csi.azure.com
     readOnly: false
-    volumeHandle: pv-handle-{{ .accountName }}-{{ .containerName }}
+    volumeHandle: {{ $namespace }}-pv-handle-{{ .accountName }}-{{ .containerName }}
     volumeAttributes:
       containerName: {{ .containerName }}
     nodeStageSecretRef:
-      name: sa-secret-{{ .accountName }}-{{.containerName}}
+      name: {{ $namespace }}-sa-secret-{{ .accountName }}-{{.containerName}}
       namespace: {{ $namespace }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ .accountName }}-{{ .containerName }}-claim1
+  name: {{ $namespace }}-{{ .accountName }}-{{ .containerName }}-claim1
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: {{ $size }}
-  volumeName: pv-blob-{{ .accountName }}-{{ .containerName }}
+  volumeName: {{ $namespace }}-pv-blob-{{ .accountName }}-{{ .containerName }}
   storageClassName: ""
 ---
 {{- end }}


### PR DESCRIPTION
Networking fixes:
If a preexisting AKS cluster is supplied, query for the vnet it belongs to, create the postgresql PE to that vnet, and use the associated private dns zone if it exists. 

Namespace Fixes:
Storage classes and persistent volume claims are not namespaced objects in Kubernetes. This prepends a namespace to the required objects to avoid conflicts in the case that multiple CoA instances are deployed into different namespaces on the same AKS cluster (customer ran into this need). Fixes #683