### PR TITLE
Set TES global managed identity to be the deployed TES MI

### DIFF
--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/tes-deployment.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/tes-deployment.yaml
@@ -99,7 +99,7 @@ spec:
             - name: BatchNodes__GlobalStartTask
               value: {{ .Values.config.batchNodes.globalStartTask }}
             - name: BatchNodes__GlobalManagedIdentity
-              value: {{ .Values.config.batchNodes.globalManagedIdentity }}
+              value: {{ .Values.identity.resourceId }}
             - name: Storage__ExternalStorageContainers
 {{- $containers  := list -}}
 {{- range .Values.externalSasContainers }}

--- a/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
@@ -14,7 +14,6 @@ config:
     subnetId: RUNTIME_PARAMETER
     disablePublicIpAddress: RUNTIME_PARAMETER
     globalStartTask: /configuration/start-task.sh
-    globalManagedIdentity:
   batchScheduling:
     disable: RUNTIME_PARAMETER
     usePreemptibleVmsOnly: RUNTIME_PARAMETER


### PR DESCRIPTION
Addresses microsoft/ga4gh-tes#444

Note that this would move CoA forward to use the new TES that features just-in-time SAS