### PR TITLE
Fix triggerservice image version.

### DIFF
--- a/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
+++ b/src/deploy-cromwell-on-azure/scripts/env-02-internal-images.txt
@@ -1,2 +1,2 @@
 ﻿TesImageName=mcr.microsoft.com/cromwellonazure/tes:5.3.1
-TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:5.3.1
+TriggerServiceImageName=mcr.microsoft.com/cromwellonazure/triggerservice:5.3.0


### PR DESCRIPTION
TES-CoA Submodule Integration Test is failing because there is no 5.3.1 release of triggerservice. 