### PR TITLE
Delete no longer needed docker image dockerfile

### DIFF
--- a/src/deploy-cromwell-on-azure/samples/docker-dockerfile
+++ b/src/deploy-cromwell-on-azure/samples/docker-dockerfile
@@ -1,5 +1,0 @@
-﻿FROM docker.io/library/docker:latest
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apk add grep
-RUN apk add bash


### PR DESCRIPTION
fixes microsoft/ga4gh-tes#279

We no longer use or need a docker-in-docker image. Removing this now obsolete file.