### PR TITLE
MCR's docker mirror for ubuntu does not include "latest"

### DIFF
--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -96,7 +96,7 @@ namespace CromwellOnAzureDeployer
         public string DeploymentContactUri { get; set; }
         public string DeploymentEnvironment { get; set; }
         public string PrivateTestUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:22.04";
-        public string PrivatePSQLUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:latest";
+        public string PrivatePSQLUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:24.04"; // mcr's docker mirror does not host "latest"
 
         public static Configuration BuildConfiguration(string[] args)
         {


### PR DESCRIPTION
Addresses #813

```
{
  "name": "mirror/docker/library/ubuntu",
  "tags": [
    "18.04",
    "20.04",
    "22.04",
    "24.04",
    "bionic",
    "focal",
    "jammy",
    "noble"
  ]
}
```