### PR TITLE
Enable specifying AksClusterName for new deployments

### DIFF
--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -97,6 +97,7 @@ namespace CromwellOnAzureDeployer
         public string DeploymentEnvironment { get; set; }
         public string PrivateTestUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:22.04";
         public string PrivatePSQLUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:24.04"; // mcr's docker mirror does not host "latest"
+        public bool? CreateMissing { get; set; } = false;
 
         public static Configuration BuildConfiguration(string[] args)
         {

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -97,7 +97,7 @@ namespace CromwellOnAzureDeployer
         public string DeploymentEnvironment { get; set; }
         public string PrivateTestUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:22.04";
         public string PrivatePSQLUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:24.04"; // mcr's docker mirror does not host "latest"
-        public bool? CreateMissing { get; set; } = false;
+        public bool? CreateMissing { get; set; } = null;
 
         public static Configuration BuildConfiguration(string[] args)
         {

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -821,7 +821,7 @@ namespace CromwellOnAzureDeployer
             }
 
             return (await GetExistingAKSClusterAsync(configuration.AksClusterName))
-                ?? throw new ValidationException($"If AKS cluster name is provided, the cluster must already exist in region {configuration.RegionName}, and be accessible to the current user.", displayExample: false);
+                ?? (configuration.CreateMissing.GetValueOrDefault() ? null : throw new ValidationException($"If AKS cluster name is provided, the cluster must already exist in region {configuration.RegionName}, and be accessible to the current user. Set {nameof(configuration.CreateMissing)} to true to create cluster with provided name.", displayExample: false));
         }
 
         private async Task<PostgreSqlFlexibleServerResource> GetExistingPostgresqlService(string serverName)
@@ -2236,8 +2236,12 @@ namespace CromwellOnAzureDeployer
 
             ThrowIfNotProvidedForUpdate(configuration.ResourceGroupName, nameof(configuration.ResourceGroupName));
 
-            ThrowIfProvidedForInstall(configuration.AksClusterName, nameof(configuration.AksClusterName));
+            if (!configuration.CreateMissing.GetValueOrDefault())
+            {
+                ThrowIfProvidedForInstall(configuration.AksClusterName, nameof(configuration.AksClusterName));
+            }
 
+            ThrowIfProvidedForUpdate(configuration.CreateMissing, nameof(configuration.CreateMissing));
             ThrowIfProvidedForUpdate(configuration.BatchPrefix, nameof(configuration.BatchPrefix));
             ThrowIfProvidedForUpdate(configuration.RegionName, nameof(configuration.RegionName));
             ThrowIfProvidedForUpdate(configuration.BatchAccountName, nameof(configuration.BatchAccountName));


### PR DESCRIPTION
fixes #817 
related to microsoft/ga4gh-tes#795

see also #518

This implementation uses `CreateMissing` to enable using the provided value of `AksClusterName` to name a new cluster if a cluster of that name does not already exist during new deployments.

Set `CreateMissing` to `true` to opt into this new behavior. `CreateMissing` cannot be used for updating deployments.