### PR TITLE
Address upgrade failure

### DIFF
--- a/src/Common/UtilityExtensions.cs
+++ b/src/Common/UtilityExtensions.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace CommonUtilities
+namespace Common
 {
     public static class UtilityExtensions
     {

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -90,7 +90,7 @@ namespace CromwellOnAzureDeployer
         public string PostgreSqlServerSslMode { get; set; } = "VerifyFull";
         public string KeyVaultName { get; set; }
         public string ContainersToMountPath { get; set; }
-        public string AadGroupIds { get; set; } // TODO: remove me
+        public string AadGroupIds { get; set; }
         public string DeploymentOrganizationName { get; set; }
         public string DeploymentOrganizationUrl { get; set; }
         public string DeploymentContactUri { get; set; }

--- a/src/deploy-cromwell-on-azure/Configuration.cs
+++ b/src/deploy-cromwell-on-azure/Configuration.cs
@@ -90,7 +90,7 @@ namespace CromwellOnAzureDeployer
         public string PostgreSqlServerSslMode { get; set; } = "VerifyFull";
         public string KeyVaultName { get; set; }
         public string ContainersToMountPath { get; set; }
-        public string AadGroupIds { get; set; }
+        public string AadGroupIds { get; set; } // TODO: remove me
         public string DeploymentOrganizationName { get; set; }
         public string DeploymentOrganizationUrl { get; set; }
         public string DeploymentContactUri { get; set; }

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1369,7 +1369,7 @@ namespace CromwellOnAzureDeployer
             _ = ConsoleEx.WriteLine($"AadGroupIds: {configuration.AadGroupIds ?? "<null>"}", ConsoleColor.Yellow);
             _ = ConsoleEx.WriteLine($"AdminGroupObjectIds: {string.Join(", ", managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? []):D}", ConsoleColor.Yellow);
             var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? [];
-            adminGroupObjectIds = adminGroupObjectIds.Count == 0 ? adminGroupObjectIds : (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
+            adminGroupObjectIds = adminGroupObjectIds.Count != 0 ? adminGroupObjectIds : (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
             _ = ConsoleEx.WriteLine($"adminGroupObjectIds: {string.Join(", ", adminGroupObjectIds):D}", ConsoleColor.Yellow);
 
             if (adminGroupObjectIds.Count == 0)

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -375,7 +375,7 @@ namespace CromwellOnAzureDeployer
                                             await Task.Delay(TimeSpan.FromMinutes(2), cts.Token);
                                         });
 
-                                    manualPrecommands = (manualPrecommands ?? []).Append("Include the following HELM command: uninstall aad-pod-identity");
+                                    manualPrecommands = (manualPrecommands ?? []).Append("Include the following HELM command: uninstall aad-pod-identity --namespace kube-system");
                                     asyncTask = _ => kubernetesManager.RemovePodAadChart();
                                 }
                             }
@@ -404,8 +404,9 @@ namespace CromwellOnAzureDeployer
 
                         if (waitForRoleAssignmentPropagation)
                         {
-                            await Execute("Waiting 5 minutes for role assignment propagation...",
-                                () => Task.Delay(TimeSpan.FromMinutes(5), cts.Token));
+                            // 10 minutes for propagation https://learn.microsoft.com/azure/role-based-access-control/troubleshooting
+                            await Execute("Waiting 10 minutes for role assignment propagation...",
+                                () => Task.Delay(TimeSpan.FromMinutes(10), cts.Token));
                         }
 
                         await kubernetesManager.UpgradeValuesYamlAsync(storageAccountData, settings, containersToMount, installedVersion);

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1779,10 +1779,10 @@ namespace CromwellOnAzureDeployer
             {
                 Dictionary<Uri, string> nationalClouds = new(
                 [
-                    new (ArmEnvironment.AzurePublicCloud.Endpoint, GraphClientFactory.Global_Cloud),
-                    new (ArmEnvironment.AzureChina.Endpoint, GraphClientFactory.China_Cloud),
+                    new(ArmEnvironment.AzurePublicCloud.Endpoint, GraphClientFactory.Global_Cloud),
+                    new(ArmEnvironment.AzureChina.Endpoint, GraphClientFactory.China_Cloud),
                     // Note that there are two different values for USGovernment.
-                    new (ArmEnvironment.AzureGovernment.Endpoint, GraphClientFactory.USGOV_Cloud), // TODO: when should we return GraphClientFactory.USGOV_DOD_Cloud?
+                    new(ArmEnvironment.AzureGovernment.Endpoint, GraphClientFactory.USGOV_Cloud), // TODO: when should we return GraphClientFactory.USGOV_DOD_Cloud?
                 ]);
 
                 string baseUrl;

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -411,10 +411,6 @@ namespace CromwellOnAzureDeployer
                             }
                         }
 
-                        //if (installedVersion is null || installedVersion < new Version(5, 4, 7))
-                        //{
-                        //}
-
                         //if (installedVersion is null || installedVersion < new Version(x, y, z))
                         //{
                         //}
@@ -1372,16 +1368,12 @@ namespace CromwellOnAzureDeployer
             var message = $"Assigning '{RoleDefinitions.GetDisplayName(RoleDefinitions.Containers.RbacClusterAdmin)}' role for {{Admins}} to AKS cluster resource scope...";
             var roleDefinitionId = GetSubscriptionRoleDefinition(RoleDefinitions.Containers.RbacClusterAdmin);
 
-            _ = ConsoleEx.WriteLine($"AadGroupIds: {configuration.AadGroupIds ?? "<null>"}", ConsoleColor.Yellow);
-            _ = ConsoleEx.WriteLine($"AdminGroupObjectIds: {string.Join(", ", managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? []):D}", ConsoleColor.Yellow);
             var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? [];
             adminGroupObjectIds = adminGroupObjectIds.Count != 0 ? adminGroupObjectIds : (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
-            _ = ConsoleEx.WriteLine($"adminGroupObjectIds: {string.Join(", ", adminGroupObjectIds):D}", ConsoleColor.Yellow);
 
             if (adminGroupObjectIds.Count == 0)
             {
                 var user = await GetUserObjectAsync();
-                _ = ConsoleEx.WriteLine($"User: {user?.Id ?? "<null>"}", ConsoleColor.Yellow);
 
                 if (user is not null)
                 {

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -361,6 +361,12 @@ namespace CromwellOnAzureDeployer
 
                         if (installedVersion is null || installedVersion < new Version(5, 4, 7)) // Previous attempt < 5.2.2
                         {
+                            var connectionString = settings["AzureServicesAuthConnectionString"];
+                            if (connectionString.Contains("RunAs=App"))
+                            {
+                                settings["AzureServicesAuthConnectionString"] = connectionString.Replace("RunAs=App", "RunAs=Workload");
+                            }
+
                             var pool = aksCluster.Data.AgentPoolProfiles.FirstOrDefault(pool => "nodepool1".Equals(pool.Name, StringComparison.OrdinalIgnoreCase));
 
                             if (!(aksCluster.Data.SecurityProfile.IsWorkloadIdentityEnabled ?? false) ||
@@ -1065,7 +1071,7 @@ namespace CromwellOnAzureDeployer
                 UpdateSetting(settings, defaults, "ApplicationInsightsAccountName", configuration.ApplicationInsightsAccountName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "AzureCloudName", configuration.AzureCloudName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "ManagedIdentityClientId", managedIdentityClientId, ignoreDefaults: true);
-                UpdateSetting(settings, defaults, "AzureServicesAuthConnectionString", managedIdentityClientId, s => $"RunAs=App;AppId={s}", ignoreDefaults: true);
+                UpdateSetting(settings, defaults, "AzureServicesAuthConnectionString", managedIdentityClientId, s => $"RunAs=Workload;AppId={s}", ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "KeyVaultName", configuration.KeyVaultName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "AksCoANamespace", configuration.AksCoANamespace, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "CrossSubscriptionAKSDeployment", configuration.CrossSubscriptionAKSDeployment);

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1526,7 +1526,7 @@ namespace CromwellOnAzureDeployer
                     .Where(a => roleDefinitionId.Equals(a.Data.RoleDefinitionId))
                     .AnyAsync(cts.Token))
                 {
-                    return;
+                    continue;
                 }
 
                 await Execute(message, () => roleAssignmentHashConflictRetryPolicy.ExecuteAsync(token =>

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1368,7 +1368,8 @@ namespace CromwellOnAzureDeployer
 
             _ = ConsoleEx.WriteLine($"AadGroupIds: {configuration.AadGroupIds ?? "<null>"}", ConsoleColor.Yellow);
             _ = ConsoleEx.WriteLine($"AdminGroupObjectIds: {string.Join(", ", managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? []):D}", ConsoleColor.Yellow);
-            var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
+            var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? [];
+            adminGroupObjectIds = adminGroupObjectIds.Count == 0 ? adminGroupObjectIds : (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
             _ = ConsoleEx.WriteLine($"adminGroupObjectIds: {string.Join(", ", adminGroupObjectIds):D}", ConsoleColor.Yellow);
 
             if (adminGroupObjectIds.Count == 0)

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1366,11 +1366,15 @@ namespace CromwellOnAzureDeployer
             var message = $"Assigning '{RoleDefinitions.GetDisplayName(RoleDefinitions.Containers.RbacClusterAdmin)}' role for {{Admins}} to AKS cluster resource scope...";
             var roleDefinitionId = GetSubscriptionRoleDefinition(RoleDefinitions.Containers.RbacClusterAdmin);
 
+            _ = ConsoleEx.WriteLine($"AadGroupIds: {configuration.AadGroupIds ?? "<null>"}", ConsoleColor.Yellow);
+            _ = ConsoleEx.WriteLine($"AdminGroupObjectIds: {string.Join(", ", managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? []):D}", ConsoleColor.Yellow);
             var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
+            _ = ConsoleEx.WriteLine($"adminGroupObjectIds: {string.Join(", ", adminGroupObjectIds):D}", ConsoleColor.Yellow);
 
             if (adminGroupObjectIds.Count == 0)
             {
                 var user = await GetUserObjectAsync();
+                _ = ConsoleEx.WriteLine($"User: {user?.Id ?? "<null>"}", ConsoleColor.Yellow);
 
                 if (user is not null)
                 {
@@ -1385,7 +1389,7 @@ namespace CromwellOnAzureDeployer
             else
             {
                 await AssignRoleToResourceAsync(
-                    configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse),
+                    adminGroupObjectIds,
                     Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType.Group,
                     managedCluster,
                     roleDefinitionId,

--- a/src/deploy-cromwell-on-azure/Deployer.cs
+++ b/src/deploy-cromwell-on-azure/Deployer.cs
@@ -1797,9 +1797,13 @@ namespace CromwellOnAzureDeployer
                     {
                         _me = await client.Me.GetAsync(cancellationToken: cts.Token);
                     }
-                    catch (Microsoft.Graph.Models.ODataErrors.ODataError ex) when ("/me request is only valid with delegated authentication flow.".Equals(ex.Message, StringComparison.Ordinal))
+                    catch (Azure.Identity.AuthenticationFailedException)
                     {
-                        ConsoleEx.WriteLine($"ODataError code: {ex.Error?.Code ?? "<null>"}");
+                        _me = null;
+                    }
+                    catch (Microsoft.Graph.Models.ODataErrors.ODataError ex) when ("BadRequest".Equals(ex.Error?.Code, StringComparison.OrdinalIgnoreCase) && ex.Message.Contains("/me", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // "/me request is only valid with delegated authentication flow."
                         _me = null;
                     }
                 }

--- a/src/deploy-cromwell-on-azure/KubernetesManager.cs
+++ b/src/deploy-cromwell-on-azure/KubernetesManager.cs
@@ -120,6 +120,12 @@ namespace CromwellOnAzureDeployer
                 await ExecHelmProcessAsync($"repo add blob-csi-driver {BlobCsiRepo}");
             }
 
+            if (helmRepoList.Contains("blob-csi-driver", StringComparison.OrdinalIgnoreCase) && !helmRepoList.Contains(BlobCsiRepo, StringComparison.OrdinalIgnoreCase))
+            {
+                await ExecHelmProcessAsync("repo remove blob-csi-driver", throwOnNonZeroExitCode: false);
+                await ExecHelmProcessAsync($"repo add blob-csi-driver {BlobCsiRepo}");
+            }
+
             await ExecHelmProcessAsync($"repo update");
             await ExecHelmProcessAsync($"upgrade --install blob-csi-driver blob-csi-driver/blob-csi-driver --set node.enableBlobfuseProxy=true --namespace kube-system --version {BlobCsiDriverGithubReleaseVersion} --kubeconfig \"{kubeConfigPath}\"");
         }

--- a/src/deploy-cromwell-on-azure/KubernetesManager.cs
+++ b/src/deploy-cromwell-on-azure/KubernetesManager.cs
@@ -217,7 +217,7 @@ namespace CromwellOnAzureDeployer
 
         public async Task RemovePodAadChart()
         {
-            await ExecHelmProcessAsync($"uninstall aad-pod-identity", throwOnNonZeroExitCode: false);
+            await ExecHelmProcessAsync($"uninstall aad-pod-identity --kubeconfig \"{kubeConfigPath}\"", throwOnNonZeroExitCode: false);
         }
 
         public async Task ExecuteCommandsOnPodAsync(IKubernetes client, string podName, IEnumerable<string[]> commands, string aksNamespace)

--- a/src/deploy-cromwell-on-azure/KubernetesManager.cs
+++ b/src/deploy-cromwell-on-azure/KubernetesManager.cs
@@ -217,7 +217,7 @@ namespace CromwellOnAzureDeployer
 
         public async Task RemovePodAadChart()
         {
-            await ExecHelmProcessAsync($"uninstall aad-pod-identity --kubeconfig \"{kubeConfigPath}\"", throwOnNonZeroExitCode: false);
+            await ExecHelmProcessAsync($"uninstall aad-pod-identity --namespace kube-system --kubeconfig \"{kubeConfigPath}\"", throwOnNonZeroExitCode: false);
         }
 
         public async Task ExecuteCommandsOnPodAsync(IKubernetes client, string podName, IEnumerable<string[]> commands, string aksNamespace)

--- a/src/deploy-cromwell-on-azure/RoleDefinitions.cs
+++ b/src/deploy-cromwell-on-azure/RoleDefinitions.cs
@@ -27,6 +27,9 @@ namespace CromwellOnAzureDeployer
                     // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-owner
                     new($"{nameof(Storage)}.{nameof(Storage.StorageBlobDataOwner)}", new(new("b7e6dc6d-f1e8-4753-8033-0f276bb0955b"), "Storage Blob Data Owner")),
 
+                    // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/containers#azure-kubernetes-service-rbac-cluster-admin
+                    new($"{nameof(Containers)}.{nameof(Containers.RbacClusterAdmin)}", new(new("b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"), "Azure Kubernetes Service RBAC Cluster Admin")),
+
                     // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/identity#managed-identity-operator
                     new($"{nameof(Identity)}.{nameof(Identity.ManagedIdentityOperator)}", new(new("f1a07417-d97a-45cb-824c-7a7467783830"), "Managed Identity Operator")),
                 ]);
@@ -61,6 +64,14 @@ namespace CromwellOnAzureDeployer
             /// Provides full access to Azure Storage blob containers and data, including assigning POSIX access control. To learn which actions are required for a given data operation, see [Permissions for calling data operations](https://learn.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory#permissions-for-calling-data-operations)/>.
             /// </summary>
             internal static Guid StorageBlobDataOwner { get; } = _roleDefinitions[$"{nameof(Storage)}.{nameof(StorageBlobDataOwner)}"].Name;
+        }
+
+        internal static class Containers
+        {
+            /// <summary>
+            /// Azure Kubernetes Fleet Manager RBAC Cluster Admin.
+            /// </summary>
+            internal static Guid RbacClusterAdmin { get; } = _roleDefinitions[$"{nameof(Containers)}.{nameof(RbacClusterAdmin)}"].Name;
         }
 
         internal static class Identity

--- a/src/deploy-cromwell-on-azure/deploy-cromwell-on-azure.csproj
+++ b/src/deploy-cromwell-on-azure/deploy-cromwell-on-azure.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Azure.ResourceManager.PrivateDns" Version="1.2.0" />
     <PackageReference Include="Azure.ResourceManager.ResourceGraph" Version="1.0.1" />
     <PackageReference Include="Azure.ResourceManager.Storage" Version="1.3.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Include="KubernetesClient" Version="15.0.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Graph" Version="5.60.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.61.0" />
     <!--Mitigate reported security issues-->
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
   </ItemGroup>

--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/identity.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/identity.yaml
@@ -4,3 +4,4 @@ metadata:
   annotations:
     azure.workload.identity/client-id: {{ .Values.identity.clientId }}
   name: {{ .Values.identity.name }}-sa
+  namespace: {{ .Values.config.coaNamespace }}

--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/tes-deployment.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/tes-deployment.yaml
@@ -66,6 +66,8 @@ spec:
               value: {{ .Values.persistence.executionsContainerName }}
             - name: AzureServicesAuthConnectionString
               value: {{ .Values.config.azureServicesAuthConnectionString }}
+            - name: AZURE_ADDITIONALLY_ALLOWED_TENANTS
+              value: "*"
             - name: ApplicationInsights__AccountName
               value: {{ .Values.config.applicationInsightsAccountName }}
             - name: BatchAccount__AccountName

--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/tes-deployment.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/tes-deployment.yaml
@@ -66,8 +66,6 @@ spec:
               value: {{ .Values.persistence.executionsContainerName }}
             - name: AzureServicesAuthConnectionString
               value: {{ .Values.config.azureServicesAuthConnectionString }}
-            - name: AZURE_ADDITIONALLY_ALLOWED_TENANTS
-              value: "*"
             - name: ApplicationInsights__AccountName
               value: {{ .Values.config.applicationInsightsAccountName }}
             - name: BatchAccount__AccountName

--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/triggerservice-deployment.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/triggerservice-deployment.yaml
@@ -44,8 +44,6 @@ spec:
               value: {{ .Values.persistence.storageAccount }}
             - name: AzureServicesAuthConnectionString
               value: {{ .Values.config.azureServicesAuthConnectionString }}
-            - name: AZURE_ADDITIONALLY_ALLOWED_TENANTS
-              value: "*"
             - name: TriggerService__ApplicationInsightsAccountName
               value: {{ .Values.config.applicationInsightsAccountName }}
             - name: TriggerService__AzureCloudName

--- a/src/deploy-cromwell-on-azure/scripts/helm/templates/triggerservice-deployment.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/templates/triggerservice-deployment.yaml
@@ -44,6 +44,8 @@ spec:
               value: {{ .Values.persistence.storageAccount }}
             - name: AzureServicesAuthConnectionString
               value: {{ .Values.config.azureServicesAuthConnectionString }}
+            - name: AZURE_ADDITIONALLY_ALLOWED_TENANTS
+              value: "*"
             - name: TriggerService__ApplicationInsightsAccountName
               value: {{ .Values.config.applicationInsightsAccountName }}
             - name: TriggerService__AzureCloudName


### PR DESCRIPTION
This changes Azure Kubernetes authentication integration to use `Azure RBAC for Kubernetes` authorization, which may require adding an azure role similar to `Azure Kubernetes Service RBAC Cluster Admin` in order to troubleshoot Kubernetes.