### PR TITLE
Remove datasettestinputs from the list of external SAS containers

### DIFF
--- a/src/deploy-cromwell-on-azure/KubernetesManager.cs
+++ b/src/deploy-cromwell-on-azure/KubernetesManager.cs
@@ -232,7 +232,7 @@ namespace CromwellOnAzureDeployer
 
                 if (datasettestinputs is not null)
                 {
-                    _ = datasettestinputs.Remove("sasToken");
+                    _ = values.ExternalSasContainers.Remove(datasettestinputs);
                 }
             }
         }

--- a/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
@@ -101,10 +101,10 @@ externalSasContainers:
 #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Public example, not confidential")]
     sasToken: "si=coa&spr=https&sv=2022-11-02&sr=c&sig=Updk4aRmzWJai%2BhtQaLjNJAVq5jwc5M4frsCBTjIj%2FM%3D"
     containerName: dataset
-  - accountName: datasettestinputs
-#[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Public example, not confidential")]
-    sasToken: "sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D"
-    containerName: dataset
+#  - accountName: datasettestinputs
+##[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Public example, not confidential")]
+#    sasToken: "sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D"
+#    containerName: dataset
 # - accountName: storageAccount
 #   sasToken: ""
 #   containerName: test-inputs

--- a/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
@@ -101,10 +101,8 @@ externalSasContainers:
 #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Public example, not confidential")]
     sasToken: "si=coa&spr=https&sv=2022-11-02&sr=c&sig=Updk4aRmzWJai%2BhtQaLjNJAVq5jwc5M4frsCBTjIj%2FM%3D"
     containerName: dataset
-#  - accountName: datasettestinputs
-##[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Public example, not confidential")]
-#    sasToken: "sv=2018-03-28&sr=c&si=coa&sig=nKoK6dxjtk5172JZfDH116N6p3xTs7d%2Bs5EAUE4qqgM%3D"
-#    containerName: dataset
+  - accountName: datasettestinputs
+    containerName: dataset
 # - accountName: storageAccount
 #   sasToken: ""
 #   containerName: test-inputs

--- a/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
+++ b/src/deploy-cromwell-on-azure/scripts/helm/values-template.yaml
@@ -101,8 +101,8 @@ externalSasContainers:
 #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Public example, not confidential")]
     sasToken: "si=coa&spr=https&sv=2022-11-02&sr=c&sig=Updk4aRmzWJai%2BhtQaLjNJAVq5jwc5M4frsCBTjIj%2FM%3D"
     containerName: dataset
-  - accountName: datasettestinputs
-    containerName: dataset
+#  - accountName: datasettestinputs
+#    containerName: dataset
 # - accountName: storageAccount
 #   sasToken: ""
 #   containerName: test-inputs


### PR DESCRIPTION
`datasettestinputs`'s `dataset` container's sample data blobs have been made publicly readable, which is not compatible with `blob.csi.azure.com`. The workaround is to use https paths instead of fuse mounts.